### PR TITLE
Overview facts are represented by 'Gtk.ListBox'

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -110,8 +110,9 @@ class MainWindow(Gtk.ApplicationWindow):
                 background: #dfdfdf;
             }
 
-            #OverviewFactsBox {
-                padding-bottom: 20px;
+            #OverviewDateLabel {
+                padding-left: 10px;
+                padding-right: 10px;
             }
 
             #OverviewTagLabel {
@@ -129,6 +130,15 @@ class MainWindow(Gtk.ApplicationWindow):
                 border-width: 1px 1px 1px 1px;
                 border-style: solid;
                 color: white;
+            }
+
+            #OverviewFactList {
+                background: @bg_color;
+            }
+
+            #OverviewFactBox {
+                padding-left: 10px;
+                padding-right: 10px;
             }
             """
 


### PR DESCRIPTION
Instead of placing widgets representing a fact (or its attributes)
right into the grid we place a ``Gtk.ListBox`` for each date. This new
container is then filled with one ``Gtk.ListBoxRow`` per fact. This has
the significant advantage that we can profit from its build in handling
of keyboard and mouse events for item selection and navigation.

Notes:
* We may run into some issues when moving between dates by keyboard, but
  that should be solveable once it is a problem.
* Our ``FactBox`` widget is added to its row with ``expand=True``. As a
  consequence its size somewhat depends on how much space the
  ``delta_widget`` takes. A consequence can be that some text of the
  ``FactBox`` flows so much to the right that it apears under the
  previous/next rows ``date_widget`` "column". This is only a minor
  issue and so far we have not found a clean way to avoid this.