### PR TITLE
#8 Provide an 'edit existing fact' dialog

### DIFF
--- a/hamster_gtk/__init__.py
+++ b/hamster_gtk/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""hamster-gtk is a Gtk based timetracking GUI build om top of ``hamsterlib``."""
+"""hamster-gtk is a Gtk based timetracking GUI build om top of ``hamster-lib``."""
 
 __author__ = 'Eric Goller'
 __email__ = 'Elbenfreund@DenkenInEchtzeit.net'

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -30,7 +30,7 @@ import gi
 gi.require_version('Gdk', '3.0')  # NOQA
 gi.require_version('Gtk', '3.0')  # NOQA
 from gi.repository import Gdk, Gtk, GObject
-import hamsterlib
+import hamster_lib
 
 from . import helpers
 from .screens.overview import OverviewScreen
@@ -174,7 +174,7 @@ class HamsterGTK(Gtk.Application):
     def _startup(self, app):
         """Triggered right at startup."""
         print(_('Hamster-GTK started.'))  # NOQA
-        self.controler = hamsterlib.HamsterControl(helpers._get_config())
+        self.controler = hamster_lib.HamsterControl(helpers._get_config())
         self.controler.signal_handler = SignalHandler()
         # For convenience only
         self.store = self.controler.store

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -22,6 +22,8 @@
 
 from __future__ import unicode_literals
 
+import traceback
+
 from gettext import gettext as _
 
 import gi
@@ -87,11 +89,8 @@ class MainWindow(Gtk.ApplicationWindow):
             Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
 
-        # Some Geometry
-
         # Set tracking as default screen at startup.
         self.add(TrackingScreen(self, self._app))
-
 
     def _get_css(self):
         """
@@ -186,7 +185,14 @@ class HamsterGTK(Gtk.Application):
     def _activate(self, app):
         """Triggered in regular use after startup."""
         if not self.window:
-            self.window = MainWindow(app)
+            # We wamt to make sure that we leave the mainloop if anything goes
+            # wrong setting up the actual window.
+            try:
+                self.window = MainWindow(app)
+            except:
+                traceback.print_exc()
+                self.quit()
+
         app.add_window(self.window)
         self.window.show_all()
         self.window.present()

--- a/hamster_gtk/screens/edit.py
+++ b/hamster_gtk/screens/edit.py
@@ -18,8 +18,9 @@
 """Module that provides the edit screen class."""
 
 from gi.repository import Gtk
+from six import text_type
 
-from hamsterlib import Fact
+from hamster_lib import Fact
 from hamster_gtk.helpers import show_error
 
 
@@ -40,7 +41,7 @@ class EditFactDialog(Gtk.Dialog):
         Args:
             parent (Gtk.Window): Parent window.
             app (Gtk.Application): Our main application  instance.
-            fact (hamsterlib.Fact): Fact instance to be edited.
+            fact (hamster_lib.Fact): Fact instance to be edited.
         """
         super(EditFactDialog, self).__init__()
         self._fact = fact
@@ -68,7 +69,7 @@ class EditFactDialog(Gtk.Dialog):
 
     def _get_old_fact_widget(self):
         """Return a widget representing the fact to be edited."""
-        label = Gtk.Label(self._fact.serialized_name)
+        label = Gtk.Label(text_type(self._fact))
         label.set_hexpand(True)
         label.set_name('EditDialogOldFactLabel')
         return label
@@ -77,12 +78,13 @@ class EditFactDialog(Gtk.Dialog):
         """Return a widget that accepts user input to provide new ``raw fact`` string."""
         entry = Gtk.Entry()
         # [FIXME]
-        # Once https://github.com/projecthamster/hamster-gtk/issues/34 is sorted
-        # this should no longer be needed.
-        label = '{start}-{end} {serialized_name}'.format(
+        # Maybe it would be sensible to have a serialization helper method as
+        # part of ``hamster-lib``?!
+        label = '{start}-{end} {activity}@{category}'.format(
             start=self._fact.start.strftime('%H:%M'),
             end=self._fact.end.strftime("%H:%M"),
-            serialized_name=self._fact.serialized_name
+            activity=text_type(self._fact.activity.name),
+            category=text_type(self._fact.category.name)
         )
         entry.set_text(label)
         entry.set_name('EditDialogRawFactEntry')

--- a/hamster_gtk/screens/edit.py
+++ b/hamster_gtk/screens/edit.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""Module that provides the edit screen class."""
+
+from gi.repository import Gtk
+
+from hamsterlib import Fact
+from hamster_gtk.helpers import show_error
+
+
+class EditFactDialog(Gtk.Dialog):
+    """
+    Dialog that allows editing of a fact instance.
+
+    The user can edit the fact in question by entering a new ``raw fact``
+    string and/or specifying particular attribute values in dedicated widgets.
+    In cases where a ``raw fact`` provided contains information in conflict
+    with values of those dedicated widgets the latter are authorative.
+    """
+
+    def __init__(self, parent, fact, app):
+        """
+        Initialize dialog.
+
+        Args:
+            parent (Gtk.Window): Parent window.
+            app (Gtk.Application): Our main application  instance.
+            fact (hamsterlib.Fact): Fact instance to be edited.
+        """
+        super(EditFactDialog, self).__init__()
+        self._fact = fact
+        self._parent = parent
+        self._app = app
+
+        self.set_transient_for(self._parent)
+        self.set_default_size(600, 200)
+        self._mainbox = Gtk.Grid()
+        self._mainbox.set_hexpand(True)
+        self._mainbox.set_vexpand(True)
+        self._mainbox.set_name('EditDialogMainBox')
+        self._mainbox.set_row_spacing(20)
+        # ``self.content_area`` is a ``Gtk.Box``. We strive for an
+        # ``Gtk.Grid`` only based layout. So we have to add this extra step.
+        self.get_content_area().add(self._mainbox)
+        self._mainbox.attach(self._get_old_fact_widget(), 0, 0, 1, 1)
+        self._raw_fact_widget = self._get_raw_fact_widget()
+        self._description_widget = self._get_description_widget()
+        self._mainbox.attach(self._raw_fact_widget, 0, 1, 1, 1)
+        self._mainbox.attach(self._description_widget, 0, 2, 1, 1)
+
+        self._add_buttons()
+        self.show_all()
+
+    def _get_old_fact_widget(self):
+        """Return a widget representing the fact to be edited."""
+        label = Gtk.Label(self._fact.serialized_name)
+        label.set_hexpand(True)
+        label.set_name('EditDialogOldFactLabel')
+        return label
+
+    def _get_raw_fact_widget(self):
+        """Return a widget that accepts user input to provide new ``raw fact`` string."""
+        entry = Gtk.Entry()
+        # [FIXME]
+        # Once https://github.com/projecthamster/hamster-gtk/issues/34 is sorted
+        # this should no longer be needed.
+        label = '{start}-{end} {serialized_name}'.format(
+            start=self._fact.start.strftime('%H:%M'),
+            end=self._fact.end.strftime("%H:%M"),
+            serialized_name=self._fact.serialized_name
+        )
+        entry.set_text(label)
+        entry.set_name('EditDialogRawFactEntry')
+        return entry
+
+    def _get_description_widget(self):
+        """Return a widget that displays and allows editing of ``fact.description``."""
+        if self._fact.description:
+            description = self._fact.description
+        else:
+            description = ''
+        window = Gtk.ScrolledWindow()
+        text_buffer = Gtk.TextBuffer()
+        text_buffer.set_text(description)
+        view = Gtk.TextView.new_with_buffer(text_buffer)
+        view.set_hexpand(True)
+        window.add(view)
+        view.set_name('EditDialogDescriptionWindow')
+        return window
+
+    def _get_raw_fact_value(self):
+        return self._raw_fact_widget.get_text().decode('utf-8')
+
+    def _get_description_value(self):
+        """Get unicode value from widget."""
+        text_view = self._description_widget.get_child()
+        text_buffer = text_view.get_buffer()
+        start, end = text_buffer.get_bounds()
+        return text_buffer.get_text(start, end, True).decode('utf-8')
+
+    def _add_buttons(self):
+        """
+        Add button widgets to the action area.
+
+        We do not use ``self.add_buttons`` because this only allows to pass on
+        strings not actual button instances. We want to pass button instances
+        however so we can customize them if we want to.
+        """
+        # [FIXME] According to http://lazka.github.io/pgi-docs/Gtk-3.0/constants.html#Gtk.STOCK_OK
+        # Stock buttons are deprecated since 3.10. The new solution however
+        # is unclear.
+        delete = Gtk.Button.new_from_stock(Gtk.STOCK_DELETE)
+        apply = Gtk.Button.new_from_stock(Gtk.STOCK_APPLY)
+        cancel = Gtk.Button.new_from_stock(Gtk.STOCK_CANCEL)
+        self.add_action_widget(delete, Gtk.ResponseType.REJECT)
+        self.add_action_widget(apply, Gtk.ResponseType.APPLY)
+        self.add_action_widget(cancel, Gtk.ResponseType.CANCEL)
+
+    def apply(self):
+        """Close dialog, updating the fact with values specified."""
+        # Create a new fact instance from the provided raw string.
+        fact = Fact.create_from_raw_fact(self._get_raw_fact_value())
+        # Instead of transfering all attributes of the parsed fact to the
+        # existing ``self._fact`` we just go the other way round and attach the
+        # old facts PK to the newly created instance.
+        fact.pk = self._fact.pk
+        # Explicit description trumps anything that may have been included in
+        # the `raw_fact``.
+        fact.description = self._get_description_value()
+        try:
+            self._app.controler.store.facts.save(fact)
+        except (ValueError, KeyError) as message:
+            show_error(self, message)
+        self._app.controler.signal_handler.emit('facts_changed')
+
+    def delete(self):
+        """Delete this fact from the backend. No further confirmation is required."""
+        result = self._app.store.facts.remove(self._fact)
+        self._app.controler.signal_handler.emit('facts_changed')
+        return result

--- a/hamster_gtk/screens/overview.py
+++ b/hamster_gtk/screens/overview.py
@@ -278,7 +278,7 @@ class FactListRow(Gtk.ListBoxRow):
         Initialize widget.
 
         Attributes:
-            fact (hamsterlib.Fact): Fact instance represented by this row.
+            fact (hamster_lib.Fact): Fact instance represented by this row.
         """
         super(FactListRow, self).__init__()
         self.fact = fact
@@ -347,7 +347,7 @@ class FactBox(Gtk.Box):
 
         Note:
             Right now, this just returns a pseudo-tag to showcase the functionality and
-            styling options because ``hamsterlib`` (0.10.0) does not support tags yet.
+            styling options because ``hamster_lib`` (0.11.0) does not support tags yet.
         """
         def get_tag_widget(name):
             tag_label = Gtk.Label()
@@ -420,7 +420,7 @@ class Charts(Gtk.Grid):
             row += 1
         return grid
 
-    # [FIXME] Place in a proper helper module. Maybe even in ``hamsterlib``?
+    # [FIXME] Place in a proper helper module. Maybe even in ``hamster-lib``?
     # In that case make sure to check if we can refactor
     # ``Fact.get_string_delta``!
     def _get_delta_string(self, delta):

--- a/hamster_gtk/screens/overview.py
+++ b/hamster_gtk/screens/overview.py
@@ -138,6 +138,10 @@ class OverviewScreen(Gtk.Dialog):
         facts_by_activity = defaultdict(list)
         activity_deltas = defaultdict(list)
 
+        GroupedFacts = namedtuple('GroupedFacts', ('by_activity', 'by_category', 'by_date'))
+        # Provide a dummy in case there are no facts to be grouped.
+        grouped_facts = GroupedFacts({}, {}, {})
+
         for fact in self._facts:
             facts_by_date[fact.date].append(fact)
             date_deltas[fact.date].append(fact.delta)
@@ -150,7 +154,6 @@ class OverviewScreen(Gtk.Dialog):
             facts_by_category[fact.category].append(fact)
             category_deltas[fact.category].append(fact.delta)
 
-            GroupedFacts = namedtuple('GroupedFacts', ('by_activity', 'by_category', 'by_date'))
             grouped_facts = GroupedFacts(
                 by_activity=facts_by_activity,
                 by_category=facts_by_category,

--- a/hamster_gtk/screens/tracking.py
+++ b/hamster_gtk/screens/tracking.py
@@ -24,7 +24,7 @@ import datetime
 from gettext import gettext as _
 
 from gi.repository import Gtk
-from hamsterlib import Fact
+from hamster_lib import Fact
 
 import hamster_gtk.helpers as helpers
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ source = hamster_gtk
 
 [isort]
 not_skip = __init__.py
-known_third_party = faker, factory, fauxfactory, gi, hamsterlib,
+known_third_party = faker, factory, fauxfactory, gi, hamster_lib,
     past, pytest, pytest_factoryboy
 
 [pytest]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
-    'hamsterlib',
+    'hamster-lib',
 ]
 
 setup(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 
-"""Test for hamsterlib."""
+"""Test for hamster-gtk."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,10 +9,13 @@ import hamster_gtk.hamster_gtk as hamster_gtk
 
 @pytest.fixture
 def app(request):
-    """Return an ``Application`` fixture."""
+    """
+    Return an ``Application`` fixture.
+
+    Please note: the app has just been started but not activated.
+    """
     app = hamster_gtk.HamsterGTK()
     app._startup(app)
-    app._activate(app)
     return app
 
 

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -36,9 +36,9 @@ class TestMainWindow(object):
 class TestHeaderBar(object):
     """Test that headerbar works as intended."""
 
-    def test_initial_anatomy(self):
+    def test_initial_anatomy(self, app_window):
         """Test that the bars initial setup is as expected."""
-        bar = hamster_gtk.HeaderBar(None)
+        bar = hamster_gtk.HeaderBar(app_window, app_window._app)
         assert bar.props.title == 'Hamster-GTK'
         assert bar.props.subtitle == 'Your friendly time tracker.'
         assert bar.props.show_close_button
@@ -47,5 +47,5 @@ class TestHeaderBar(object):
     def test_on_overview_button_overview_exists(self, app_window):
         """Test that we don't create a new overview if we already have one."""
         app_window.overview = True
-        bar = hamster_gtk.HeaderBar(app_window)
+        bar = hamster_gtk.HeaderBar(app_window, app_window._app)
         assert bar._on_overview_button(None) is None


### PR DESCRIPTION
#Dialog opens when a row in the overview is ``activated``.

This PR also makes sure that the ``HamsterGTK`` application is passed
along to all major players in a consistent and transparent way instead
of hoping to be able to access it as some parent window attribute.

A thing to notice is: The string used to populate the ``raw fact`` aka
``activity`` entry widget contains a proper raw fact now. That is a
legacy ``serialized_name`` prepended with the facts time info.
Another difference is that ``time frame`` is given in the proper format
where ``start`` and ``end`` are seperated by an ``-`` not by an `` `` as
in the legacy version. Whilst this breaks the previous string, it should
be alright and gets us one step closer to higher code consistency.

A new ``SignalHandler`` class is added that can be used to register
generic custom signals. This may not be the idiomatic way to do this but
then agian, is rather confusing finding any consistent information on
this matter to begin with. Instead of creating a new 'controler` class
inheriting from ``HamsterControler`` *and* ``GObject`` we opted for
``composition`` instead.  An instance of this class is added as
``HamsterGTa.controler.signal_handler`` and provides an easy way to
emit custom signals.

With regards to ``EditFactDialog.apply``:
Instead of parsing the ``raw_fact`` and tranfering the attributes to
``self._fact`` we cheat a bit and stick with the new instance and just
attach the PK of the fact to be updated before we pass it off to
``hamsterlib``.

This PR does not include any visual representation day representation like the original hamster did (``widgets.DayLine()``). This will be added in a separate issue.

Closes: #8