### PR TITLE
Add Dialog to pick daterange for overview (#39)

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -29,8 +29,8 @@ from gettext import gettext as _
 import gi
 gi.require_version('Gdk', '3.0')  # NOQA
 gi.require_version('Gtk', '3.0')  # NOQA
-from gi.repository import Gdk, Gtk, GObject
 import hamster_lib
+from gi.repository import Gdk, GObject, Gtk
 
 from . import helpers
 from .screens.overview import OverviewScreen
@@ -152,6 +152,7 @@ class SignalHandler(GObject.GObject):
 
     __gsignals__ = {
         str('facts-changed'): (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, ()),
+        str('daterange-changed'): (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, ()),
     }
 
     def __init__(self):

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -74,3 +74,9 @@ def clear_children(widget):
     for child in widget.get_children():
         child.destroy()
     return widget
+
+
+def calendar_date_to_datetime(date):
+    """Convert :meth:`Gtk.Calendar.get_date` value to :class:`datetime.date`."""
+    year, month, day = date
+    return datetime.date(int(year), int(month) + 1, int(day))

--- a/hamster_gtk/screens/edit.py
+++ b/hamster_gtk/screens/edit.py
@@ -18,9 +18,9 @@
 """Module that provides the edit screen class."""
 
 from gi.repository import Gtk
+from hamster_lib import Fact
 from six import text_type
 
-from hamster_lib import Fact
 from hamster_gtk.helpers import show_error
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ source = hamster_gtk
 
 [isort]
 not_skip = __init__.py
-known_third_party = faker, factory, fauxfactory, gi, hamster_lib,
+known_third_party = faker, factory, fauxfactory, freezegun, gi, hamster_lib,
     past, pytest, pytest_factoryboy
 
 [pytest]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,17 @@
 
 """Unittest fixtures."""
 
+import datetime
+
+import fauxfactory
 import pytest
+from gi.repository import Gtk
 
 import hamster_gtk.hamster_gtk as hamster_gtk
+import hamster_gtk.screens.overview as overview
 
 
+# Instances
 @pytest.fixture
 def app(request):
     """
@@ -23,3 +29,78 @@ def app(request):
 def app_window(request, app):
     """Return a ``ApplicationWindow`` fixture."""
     return hamster_gtk.MainWindow(app)
+
+
+@pytest.fixture
+def dummy_window(self):
+    """
+    Return a generic :class:`Gtk.Window` instance.
+
+    This is useful for tests that do not actually rely on external
+    functionality.
+    """
+    return Gtk.Window()
+
+
+@pytest.fixture
+def overview_screen(app_window, app):
+    """Return a generic :class:`OverViewDialog` instance."""
+    return overview.OverviewScreen(app_window, app)
+
+
+@pytest.fixture
+def daterange_select_dialog(overview_screen):
+    """Return a functional DateRangeSelectDialog instance."""
+    return overview.DateRangeSelectDialog(overview_screen)
+
+
+# Data
+@pytest.fixture(params=(
+    fauxfactory.gen_string('utf8'),
+    fauxfactory.gen_string('cjk'),
+    fauxfactory.gen_string('latin1'),
+    fauxfactory.gen_string('cyrillic'),
+))
+def word_parametrized(request):
+    """Return a string paramized with various different charakter constelations."""
+    return request.param
+
+
+@pytest.fixture(params=(0, 7, 15, 30, 55))
+def daterange_offset_parametrized(request):
+    """Return various daterange offset variants as easy to use timedeltas."""
+    return datetime.timedelta(days=request.param)
+
+
+@pytest.fixture
+def daterange(request):
+    """Return a randomized daterange tuple."""
+    offset = datetime.timedelta(days=7)
+    start = fauxfactory.gen_date()
+    return (start, start + offset)
+
+
+@pytest.fixture
+def daterange_parametrized(request, daterange_offset_parametrized):
+    """Return daterange parametrized with various lengths."""
+    start = fauxfactory.gen_date()
+    return (start, start + daterange_offset_parametrized)
+
+
+@pytest.fixture(params=(
+    (datetime.date(2016, 7, 10), (datetime.date(2016, 7, 4), datetime.date(2016, 7, 10))),
+    (datetime.date(2016, 7, 1), (datetime.date(2016, 6, 27), datetime.date(2016, 7, 3))),
+    (datetime.date(2016, 7, 18), (datetime.date(2016, 7, 18), datetime.date(2016, 7, 24))),
+))
+def weekrange_parametrized(request):
+    """Return parametrized ``date``/``weekrange`` pairs."""
+    return request.param
+
+
+@pytest.fixture(params=(
+    (datetime.date(2016, 7, 10), (datetime.date(2016, 7, 1), datetime.date(2016, 7, 31))),
+    (datetime.date(2016, 2, 2), (datetime.date(2016, 2, 1), datetime.date(2016, 2, 29))),
+))
+def monthrange_parametrized(request):
+    """Return parametrized ``date``/``monthrange`` pairs."""
+    return request.param

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -2,9 +2,14 @@
 
 from __future__ import unicode_literals
 
+import datetime
+
+from freezegun import freeze_time
+from gi.repository import Gtk
 from six import text_type
 
-from hamster_gtk import hamster_gtk
+from hamster_gtk import hamster_gtk, helpers
+from hamster_gtk.screens import overview
 from hamster_gtk.screens.tracking import TrackingScreen
 
 
@@ -49,3 +54,131 @@ class TestHeaderBar(object):
         app_window.overview = True
         bar = hamster_gtk.HeaderBar(app_window, app_window._app)
         assert bar._on_overview_button(None) is None
+
+
+class TestOverviewScreen(object):
+    """Unittests for the overview dialog."""
+
+    def test_daterange(self, request):
+        """Test that we return the right attribute."""
+        pass
+
+    def test_daterange_emit_signal(self, request):
+        """Test that setting a daterange emit the right signal."""
+        pass
+
+
+class TestDateRangeSelectDialog(object):
+    """Unittests for the daterange select dialog."""
+
+    def test_init(self, overview_screen):
+        assert overview.DateRangeSelectDialog(overview_screen)
+
+    def test_daterange_getter(self, daterange_select_dialog, daterange_parametrized):
+        """Make sure a tuple of start- end enddate is returned."""
+        start, end = daterange_parametrized
+        daterange_select_dialog._start_calendar.select_month(start.month - 1, start.year)
+        daterange_select_dialog._start_calendar.select_day(start.day)
+        daterange_select_dialog._end_calendar.select_month(end.month - 1, end.year)
+        daterange_select_dialog._end_calendar.select_day(end.day)
+        assert daterange_select_dialog.daterange == daterange_parametrized
+
+    def test_daterange_setter(self, daterange_select_dialog, daterange_parametrized):
+        """Make sure the correct start- and endtime is set on the calendars."""
+        start, end = daterange_parametrized
+        dialog = daterange_select_dialog
+        daterange_select_dialog.daterange = daterange_parametrized
+        assert helpers.calendar_date_to_datetime(dialog._start_calendar.get_date()) == start
+        assert helpers.calendar_date_to_datetime(dialog._end_calendar.get_date()) == end
+
+    def test__get_apply_button(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_apply_button()
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_today_widget(self, daterange_select_dialog, mocker):
+        """Make sure widget matches expectation."""
+        daterange_select_dialog._on_today_button_clicked = mocker.MagicMock()
+        result = daterange_select_dialog._get_today_widget()
+        result.emit('clicked')
+        assert daterange_select_dialog._on_today_button_clicked.called
+
+    def test__get_week_widget(self, daterange_select_dialog, mocker):
+        """Make sure widget matches expectation."""
+        daterange_select_dialog._on_week_button_clicked = mocker.MagicMock()
+        result = daterange_select_dialog._get_week_widget()
+        result.emit('clicked')
+        assert daterange_select_dialog._on_week_button_clicked.called
+
+    def test__get_month_widget(self, daterange_select_dialog, mocker):
+        """Make sure widget matches expectation."""
+        daterange_select_dialog._on_month_button_clicked = mocker.MagicMock()
+        result = daterange_select_dialog._get_month_widget()
+        result.emit('clicked')
+        assert daterange_select_dialog._on_month_button_clicked.called
+
+    def test__get_start_calendar(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_start_calendar()
+        assert isinstance(result, Gtk.Calendar)
+
+    def test__get_end_calendar(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_end_calendar()
+        assert isinstance(result, Gtk.Calendar)
+
+    def test__get_custom_range_label(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_custom_range_label()
+        assert isinstance(result, Gtk.Label)
+
+    def test__get_custom_range_connection_label(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_custom_range_connection_label()
+        assert isinstance(result, Gtk.Label)
+
+    def test__get_double_label_button(self, daterange_select_dialog, word_parametrized):
+        """Make sure widget matches expectation."""
+        l_label = word_parametrized
+        r_label = word_parametrized
+        result = daterange_select_dialog._get_double_label_button(l_label, r_label)
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_week_range(self, daterange_select_dialog, weekrange_parametrized):
+        """Make the right daterange is returned."""
+        date, expectation = weekrange_parametrized
+        result = daterange_select_dialog._get_week_range(date)
+        assert result == expectation
+
+    def test__get_month_range(self, daterange_select_dialog, monthrange_parametrized):
+        """Make the right daterange is returned."""
+        date, expectation = monthrange_parametrized
+        result = daterange_select_dialog._get_month_range(date)
+        assert result == expectation
+
+    @freeze_time('2016-04-01')
+    def test__on_today_button_clicked(self, daterange_select_dialog, mocker):
+        """Test that 'datetime' is set to today and right response is triggered."""
+        daterange_select_dialog.response = mocker.MagicMock()
+        daterange_select_dialog._on_today_button_clicked(None)
+        assert daterange_select_dialog.daterange == (datetime.date(2016, 4, 1),
+                                                     datetime.date(2016, 4, 1))
+        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)
+
+    @freeze_time('2016-04-01')
+    def test__on_week_button_clicked(self, daterange_select_dialog, mocker):
+        """Test that 'datetime' is set to 'this week' and right response is triggered."""
+        daterange_select_dialog.response = mocker.MagicMock()
+        daterange_select_dialog._on_week_button_clicked(None)
+        assert daterange_select_dialog.daterange == (datetime.date(2016, 3, 28),
+                                                     datetime.date(2016, 4, 3))
+        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)
+
+    @freeze_time('2016-04-01')
+    def test__on_month_button_clicked(self, daterange_select_dialog, mocker):
+        """Test that 'datetime' is set to 'this month' and right response is triggered."""
+        daterange_select_dialog.response = mocker.MagicMock()
+        daterange_select_dialog._on_month_button_clicked(None)
+        assert daterange_select_dialog.daterange == (datetime.date(2016, 4, 1),
+                                                     datetime.date(2016, 4, 30))
+        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)


### PR DESCRIPTION
We could not implement the original design as we try not to cheat the way it does ;) The original glade file uses a fixed width for 'today', 'week', and 'range' labels to make it apear as if there is an underlying
grid layout. However, if one wants to go with the 'wide button' design, a proper grid layout is not an option.

Our best first aproximation now is to use ``Align.START`` and ``Align.END``  to try to create a good locking compromise. This is most likly a place to return to once we want to polish things. We try hard to make it as modular and transparent as possible. So such changes should be relatively easy if someone with some GTK mojo want to have a go.

On the functional side of things this PR introduces a new ``daterange`` property to the overview screen. It stores the range of dates to be considered when collecting facts to be displayed. In order
to be as flexible as possible a new signal ``daterange-changed`` will be emited by the main app signal handler whenever this value is changed.

Note: We finally start writing proper tests for our widgets. Its gonna get better from here on out...

Note: An alternative design option would be to provide three preset button in a titlebar.

Closes: #39