### PR TITLE
[#43] Refactor parent relations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,44 @@
 # Config file for automatic testing at travis-ci.org
 # This file will be regenerated if you run travis_pypi_setup.py
 
+sudo: required
+dist: trusty
+
 language: python
+python:
+    - "2.7"
 
-env:
-  - TOXENV=flake8
-  - TOXENV=pep257
-   #- TOXENV=docs
-  - TOXENV=manifest
+cache: pip
 
+addons:
+  apt:
+    packages:
+    - gir1.2-pango-1.0
+    - gir1.2-gtk-3.0
+    - libglib2.0-dev
+    - libgtk-3-dev
+    - python-gi
+    - python-cairo
+    - python-gi-cairo
+    # - python3-gobject Provided by python3-gi
+    #- python3-gi
+    #- python3-cairo
+    #- python3-gi-cairo
+
+virtualenv:
+  system_site_packages: true
 
 before_install:
-  - pip install codecov
+    #- pip install codecov
+  - pip install --upgrade pip
+  - pip install -r requirements/test.pip
+  - sudo apt-get install --only-upgrade libgtk-3-dev
 
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install:
-  - pip install -U tox codecov
-
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 # command to run tests, e.g. python setup.py test
 script:
-  - make test-all
+    - tox
+#- py.test --verbose tests

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ help:
 	@echo "   test-all      to run tests on every Python version with tox"
 	@echo "   coverage      to check code coverage quickly with the default Python"
 	@echo "   coverage-html"
+	@echo "   codecov"
 	@echo "   develop       to install (or update) all packages required for development"
 	@echo "   docs          to generate Sphinx HTML documentation, including API docs"
 	@echo "   isort         to run isort on the whole project."
@@ -81,6 +82,9 @@ test2:
 coverage-html: coverage
 	coverage html
 	$(BROWSER) htmlcov/index.html
+
+codecov: coverage
+	codecov --token=96b66aeb-8d82-4d44-8ff7-93ac5d5305b9
 
 docs:
 	rm -f docs/hamster_gtk.rst

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ source = hamster_gtk
 
 [isort]
 not_skip = __init__.py
-known_third_party = faker, factory, fauxfactory, freezegun, gi, hamster_lib,
+known_third_party = faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
     past, pytest, pytest_factoryboy
 
 [pytest]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,58 @@
+# -*- encoding: utf-8 -*-
+
+"""Factories providing randomized object instances."""
+
+from __future__ import unicode_literals
+
+import datetime
+
+import factory
+import fauxfactory
+from future.utils import python_2_unicode_compatible
+from hamster_lib import objects
+
+
+@python_2_unicode_compatible
+class CategoryFactory(factory.Factory):
+    """Factory providing randomized ``hamster_lib.Category`` instances."""
+
+    pk = None
+    # Although we do not need to reference to the object beeing created and
+    # ``LazyFunction`` seems sufficient it is not as we could not pass on the
+    # string encoding. ``LazyAttribute`` allows us to specify a lambda that
+    # circumvents this problem.
+    name = factory.LazyAttribute(lambda x: fauxfactory.gen_string('utf8'))
+
+    class Meta:
+        model = objects.Category
+
+
+@python_2_unicode_compatible
+class ActivityFactory(factory.Factory):
+    """Factory providing randomized ``hamster_lib.Activity`` instances."""
+
+    pk = None
+    name = factory.Faker('word')
+    category = factory.SubFactory(CategoryFactory)
+    deleted = False
+
+    class Meta:
+        model = objects.Activity
+
+
+@python_2_unicode_compatible
+class FactFactory(factory.Factory):
+    """
+    Factory providing randomized ``hamster_lib.Category`` instances.
+
+    Instances have a duration of 3 hours.
+    """
+
+    pk = None
+    activity = factory.SubFactory(ActivityFactory)
+    start = factory.Faker('date_time')
+    end = factory.LazyAttribute(lambda o: o.start + datetime.timedelta(hours=3))
+    description = factory.Faker('paragraph')
+
+    class Meta:
+        model = objects.Fact

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+from hamster_gtk import dialogs
+
+
+class TestErrorDialog(object):
+    """Unittests for ErrorDialog."""
+
+    def test_init_with_parent_window(self, dummy_window):
+        """Test instances where toplevel is a window instance."""
+        result = dialogs.ErrorDialog(dummy_window, '')
+        assert result

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+
+from gi.repository import Gtk
+
+from hamster_gtk.screens import edit
+
+
+class TestEditFactDialog(object):
+    """Unittests for the edit dialog."""
+
+    def test_init(self, fact, dummy_window):
+        result = edit.EditFactDialog(dummy_window, fact)
+        assert result
+
+    def test__get_main_box(self, edit_fact_dialog):
+        """Make sure the returned container matches expectation."""
+        result = edit_fact_dialog._get_main_box()
+        assert len(result.get_children()) == 3
+        assert isinstance(result, Gtk.Grid)
+
+    def test__get_old_fact_widget(self, edit_fact_dialog):
+        """Test the widget representing the original fact."""
+        result = edit_fact_dialog._get_old_fact_widget()
+        assert isinstance(result, Gtk.Label)
+
+    def test__get_raw_fact_widget(self, edit_fact_dialog):
+        """Test the widget representing the new fact."""
+        result = edit_fact_dialog._get_raw_fact_widget()
+        assert isinstance(result, Gtk.Entry)
+
+    def test__get_desciption_widget(self, edit_fact_dialog):
+        """Test the description widget matches expectation."""
+        result = edit_fact_dialog._get_description_widget()
+        assert isinstance(result, Gtk.ScrolledWindow)
+
+    def test__get_delete_button(self, edit_fact_dialog):
+        """Make sure the delete button matches expectations."""
+        result = edit_fact_dialog._get_delete_button()
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_apply_button(self, edit_fact_dialog):
+        """Make sure the apply button matches expectations."""
+        result = edit_fact_dialog._get_apply_button()
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_cancel_button(self, edit_fact_dialog):
+        """Make sure the cancel button matches expectations."""
+        result = edit_fact_dialog._get_cancel_button()
+        assert isinstance(result, Gtk.Button)
+
+    # [FIXME]
+    # Add tests for changed values.
+    def test_updated_fact_same(self, dummy_window, fact):
+        """
+        Make sure the property returns Fact matching field values.
+
+        We need to jump through some extra hoops because we the current
+        implementation will always set the edited fact to today as well as ignore
+        all 'second' time info.
+        """
+        dialog = edit.EditFactDialog(dummy_window, fact)
+        today = datetime.date.today()
+        fact.start = datetime.datetime.combine(today, fact.start.time()).replace(second=0)
+        fact.end = datetime.datetime.combine(today, fact.end.time()).replace(second=0)
+        result = dialog.updated_fact
+        assert result.as_tuple() == fact.as_tuple()

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -2,14 +2,10 @@
 
 from __future__ import unicode_literals
 
-import datetime
-
-from freezegun import freeze_time
 from gi.repository import Gtk
 from six import text_type
 
-from hamster_gtk import hamster_gtk, helpers
-from hamster_gtk.screens import overview
+from hamster_gtk import hamster_gtk
 from hamster_gtk.screens.tracking import TrackingScreen
 
 
@@ -29,31 +25,38 @@ class TestMainWindow(object):
         """Make sure class setup works up as intended."""
         window = hamster_gtk.MainWindow(app)
         assert isinstance(window.get_titlebar(), hamster_gtk.HeaderBar)
-        assert isinstance(window._app, hamster_gtk.HamsterGTK)
-        assert window.get_size() == hamster_gtk.DEFAULT_WINDOW_SIZE
+        assert isinstance(window.app, hamster_gtk.HamsterGTK)
         assert isinstance(window.get_children()[0], TrackingScreen)
 
-    def test_get_css(self, app_window):
+    def test_get_css(self, main_window):
         """Make sure a string is returned."""
-        assert isinstance(app_window._get_css(), text_type)
+        assert isinstance(main_window._get_css(), text_type)
 
 
 class TestHeaderBar(object):
-    """Test that headerbar works as intended."""
+    """Unittests for main window titlebar."""
 
-    def test_initial_anatomy(self, app_window):
+    def test_initial_anatomy(self, header_bar):
         """Test that the bars initial setup is as expected."""
-        bar = hamster_gtk.HeaderBar(app_window, app_window._app)
-        assert bar.props.title == 'Hamster-GTK'
-        assert bar.props.subtitle == 'Your friendly time tracker.'
-        assert bar.props.show_close_button
-        assert len(bar.get_children()) == 1
+        assert header_bar.props.title == 'Hamster-GTK'
+        assert header_bar.props.subtitle == 'Your friendly time tracker.'
+        assert header_bar.props.show_close_button
+        assert len(header_bar.get_children()) == 1
 
-    def test_on_overview_button_overview_exists(self, app_window):
-        """Test that we don't create a new overview if we already have one."""
-        app_window.overview = True
-        bar = hamster_gtk.HeaderBar(app_window, app_window._app)
-        assert bar._on_overview_button(None) is None
+    def test__get_oheader_barview_button(self, header_bar, mocker):
+        """Test that that button returned matches expectation."""
+        header_bar._on_overview_button = mocker.MagicMock()
+        result = header_bar._get_overview_button()
+        assert isinstance(result, Gtk.Button)
+        result.emit('clicked')
+        assert header_bar._on_overview_button.called
+
+    def test__on_overview_button(self, main_window, mocker):
+        """Make sure a new overview is created if none exist."""
+        bar = main_window.get_titlebar()
+        overview_class = mocker.patch('hamster_gtk.hamster_gtk.OverviewScreen')
+        bar._on_overview_button(None)
+        assert overview_class.called
 
 
 class TestOverviewScreen(object):
@@ -66,119 +69,3 @@ class TestOverviewScreen(object):
     def test_daterange_emit_signal(self, request):
         """Test that setting a daterange emit the right signal."""
         pass
-
-
-class TestDateRangeSelectDialog(object):
-    """Unittests for the daterange select dialog."""
-
-    def test_init(self, overview_screen):
-        assert overview.DateRangeSelectDialog(overview_screen)
-
-    def test_daterange_getter(self, daterange_select_dialog, daterange_parametrized):
-        """Make sure a tuple of start- end enddate is returned."""
-        start, end = daterange_parametrized
-        daterange_select_dialog._start_calendar.select_month(start.month - 1, start.year)
-        daterange_select_dialog._start_calendar.select_day(start.day)
-        daterange_select_dialog._end_calendar.select_month(end.month - 1, end.year)
-        daterange_select_dialog._end_calendar.select_day(end.day)
-        assert daterange_select_dialog.daterange == daterange_parametrized
-
-    def test_daterange_setter(self, daterange_select_dialog, daterange_parametrized):
-        """Make sure the correct start- and endtime is set on the calendars."""
-        start, end = daterange_parametrized
-        dialog = daterange_select_dialog
-        daterange_select_dialog.daterange = daterange_parametrized
-        assert helpers.calendar_date_to_datetime(dialog._start_calendar.get_date()) == start
-        assert helpers.calendar_date_to_datetime(dialog._end_calendar.get_date()) == end
-
-    def test__get_apply_button(self, daterange_select_dialog):
-        """Make sure widget matches expectation."""
-        result = daterange_select_dialog._get_apply_button()
-        assert isinstance(result, Gtk.Button)
-
-    def test__get_today_widget(self, daterange_select_dialog, mocker):
-        """Make sure widget matches expectation."""
-        daterange_select_dialog._on_today_button_clicked = mocker.MagicMock()
-        result = daterange_select_dialog._get_today_widget()
-        result.emit('clicked')
-        assert daterange_select_dialog._on_today_button_clicked.called
-
-    def test__get_week_widget(self, daterange_select_dialog, mocker):
-        """Make sure widget matches expectation."""
-        daterange_select_dialog._on_week_button_clicked = mocker.MagicMock()
-        result = daterange_select_dialog._get_week_widget()
-        result.emit('clicked')
-        assert daterange_select_dialog._on_week_button_clicked.called
-
-    def test__get_month_widget(self, daterange_select_dialog, mocker):
-        """Make sure widget matches expectation."""
-        daterange_select_dialog._on_month_button_clicked = mocker.MagicMock()
-        result = daterange_select_dialog._get_month_widget()
-        result.emit('clicked')
-        assert daterange_select_dialog._on_month_button_clicked.called
-
-    def test__get_start_calendar(self, daterange_select_dialog):
-        """Make sure widget matches expectation."""
-        result = daterange_select_dialog._get_start_calendar()
-        assert isinstance(result, Gtk.Calendar)
-
-    def test__get_end_calendar(self, daterange_select_dialog):
-        """Make sure widget matches expectation."""
-        result = daterange_select_dialog._get_end_calendar()
-        assert isinstance(result, Gtk.Calendar)
-
-    def test__get_custom_range_label(self, daterange_select_dialog):
-        """Make sure widget matches expectation."""
-        result = daterange_select_dialog._get_custom_range_label()
-        assert isinstance(result, Gtk.Label)
-
-    def test__get_custom_range_connection_label(self, daterange_select_dialog):
-        """Make sure widget matches expectation."""
-        result = daterange_select_dialog._get_custom_range_connection_label()
-        assert isinstance(result, Gtk.Label)
-
-    def test__get_double_label_button(self, daterange_select_dialog, word_parametrized):
-        """Make sure widget matches expectation."""
-        l_label = word_parametrized
-        r_label = word_parametrized
-        result = daterange_select_dialog._get_double_label_button(l_label, r_label)
-        assert isinstance(result, Gtk.Button)
-
-    def test__get_week_range(self, daterange_select_dialog, weekrange_parametrized):
-        """Make the right daterange is returned."""
-        date, expectation = weekrange_parametrized
-        result = daterange_select_dialog._get_week_range(date)
-        assert result == expectation
-
-    def test__get_month_range(self, daterange_select_dialog, monthrange_parametrized):
-        """Make the right daterange is returned."""
-        date, expectation = monthrange_parametrized
-        result = daterange_select_dialog._get_month_range(date)
-        assert result == expectation
-
-    @freeze_time('2016-04-01')
-    def test__on_today_button_clicked(self, daterange_select_dialog, mocker):
-        """Test that 'datetime' is set to today and right response is triggered."""
-        daterange_select_dialog.response = mocker.MagicMock()
-        daterange_select_dialog._on_today_button_clicked(None)
-        assert daterange_select_dialog.daterange == (datetime.date(2016, 4, 1),
-                                                     datetime.date(2016, 4, 1))
-        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)
-
-    @freeze_time('2016-04-01')
-    def test__on_week_button_clicked(self, daterange_select_dialog, mocker):
-        """Test that 'datetime' is set to 'this week' and right response is triggered."""
-        daterange_select_dialog.response = mocker.MagicMock()
-        daterange_select_dialog._on_week_button_clicked(None)
-        assert daterange_select_dialog.daterange == (datetime.date(2016, 3, 28),
-                                                     datetime.date(2016, 4, 3))
-        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)
-
-    @freeze_time('2016-04-01')
-    def test__on_month_button_clicked(self, daterange_select_dialog, mocker):
-        """Test that 'datetime' is set to 'this month' and right response is triggered."""
-        daterange_select_dialog.response = mocker.MagicMock()
-        daterange_select_dialog._on_month_button_clicked(None)
-        assert daterange_select_dialog.daterange == (datetime.date(2016, 4, 1),
-                                                     datetime.date(2016, 4, 30))
-        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import gi
-gi.require_version('Gdk', '3.0')  # NOQA
 from gi.repository import Gtk
+
+gi.require_version('Gdk', '3.0')  # NOQA
 
 
 def test_minimal(request):

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+
+"""
+Most of the widget related methods are tested very naivly. Hardly any
+properties are checked right now. It is mostly about checking if they can be
+instantiated at all.
+Once the actuall design/layout becomes more solidified it may be worth while to
+elaborate on those. It should be fairly simple now that we provide the
+infrastructure.
+"""
+
+import datetime
+
+import pytest
+from freezegun import freeze_time
+from gi.repository import Gtk
+
+from hamster_gtk import helpers
+from hamster_gtk.screens import overview
+
+
+class TestFactGrid(object):
+    """Unittests for FactGrid."""
+
+    def test_init(self, app):
+        """Make sure minimal initialisation works."""
+        fact_grid = overview.FactGrid(app.controler, {})
+        assert fact_grid
+
+    def test__get_date_widget(self, fact_grid):
+        """Make sure expected label is returned."""
+        result = fact_grid._get_date_widget(datetime.date.today())
+        assert isinstance(result, Gtk.EventBox)
+
+    def test__get_fact_list(self, app, fact_grid):
+        """Make sure a FactListBox is retuned."""
+        result = fact_grid._get_fact_list(app.controler, [])
+        assert isinstance(result, overview.FactListBox)
+
+
+class TestFactListBox(object):
+    """Unittest for FactListBox."""
+
+    def test_init(self, app, set_of_facts):
+        """Test that instantiation works as expected."""
+        result = overview.FactListBox(app.controler, set_of_facts)
+        assert isinstance(result, overview.FactListBox)
+        assert len(result.get_children()) == len(set_of_facts)
+
+    def test__on_activate_reject(self, fact_list_box, fact, mocker):
+        """Make sure an edit dialog is created, processed and then destroyed."""
+        fact_list_box.get_toplevel = Gtk.Window
+        mocker.patch('hamster_gtk.screens.overview.EditFactDialog.run',
+                     return_value=Gtk.ResponseType.REJECT)
+        fact_list_box._delete_fact = mocker.MagicMock()
+        row = mocker.MagicMock()
+        row.fact = fact
+        fact_list_box._on_activate(None, row)
+        assert fact_list_box._delete_fact.called
+
+    def test__on_activate_apply(self, fact_list_box, fact, mocker):
+        """Make sure an edit dialog is created, processed and then destroyed."""
+        fact_list_box.get_toplevel = Gtk.Window
+        mocker.patch('hamster_gtk.screens.overview.EditFactDialog.run',
+                     return_value=Gtk.ResponseType.APPLY)
+        fact_list_box._update_fact = mocker.MagicMock()
+        row = mocker.MagicMock()
+        row.fact = fact
+        fact_list_box._on_activate(None, row)
+        assert fact_list_box._update_fact.called
+
+
+class TestFactListRow(object):
+    """Unittests for FactListRow."""
+
+    def test_init(self, fact):
+        """Make sure instantiated object matches expectations."""
+        result = overview.FactListRow(fact)
+        assert isinstance(result, overview.FactListRow)
+        hbox = result.get_children()[0]
+        children = hbox.get_children()
+        assert isinstance(children[0], Gtk.Label)
+        assert isinstance(children[1], overview.FactBox)
+        assert isinstance(children[2], Gtk.EventBox)
+
+    def test_get_time_widget(self, factlist_row, fact):
+        """Make sure widget matches expectations."""
+        result = factlist_row._get_time_widget(fact)
+        assert isinstance(result, Gtk.Label)
+
+    def test_get_delta_widget(self, factlist_row, fact):
+        """Make sure widget matches expectations."""
+        result = factlist_row._get_delta_widget(fact)
+        assert isinstance(result, Gtk.EventBox)
+
+
+class TestFactBox(object):
+    """Unittests for FactBox."""
+
+    def test_init(self, fact):
+        """Make sure instantiated object matches expectations."""
+        result = overview.FactBox(fact)
+        assert isinstance(result, overview.FactBox)
+        assert len(result.get_children()) == 3
+
+    def test_init_without_description(self, fact):
+        """Make sure instantiated object matches expectations."""
+        fact.description = ''
+        result = overview.FactBox(fact)
+        assert isinstance(result, overview.FactBox)
+        assert len(result.get_children()) == 2
+
+    def test__get_activity_widget(self, factbox, fact):
+        """Make sure instantiated object matches expectations."""
+        result = factbox._get_activity_widget(fact)
+        assert isinstance(result, Gtk.Label)
+
+    def test__get_tags_widget(self, factbox, fact):
+        """Make sure instantiated object matches expectations."""
+        # [FIXME]
+        # Once the method is not just using a dummy tag, this needs to be
+        # refactored.
+        result = factbox._get_tags_widget(fact)
+        assert isinstance(result, Gtk.Box)
+        assert len(result.get_children()) == 1
+
+    def test__get_desciption_widget(self, factbox, fact):
+        """Make sure instantiated object matches expectations."""
+        result = factbox._get_description_widget(fact)
+        assert isinstance(result, Gtk.Label)
+        result = factbox._get_description_widget(fact)
+        assert isinstance(result, Gtk.Label)
+
+
+class TestCharts(object):
+    """Unittests for Charts."""
+
+    def test_init(self, totals):
+        """Make sure instance matches expectation."""
+        result = overview.Charts(totals)
+        assert isinstance(result, overview.Charts)
+        assert len(result.get_children()) == 1
+
+    def test__get_category_widget(self, charts, totals):
+        """Make sure widget matches expectations."""
+        result = charts._get_category_widget(totals.category)
+        assert isinstance(result, Gtk.Grid)
+        # Each category will trigger adding 3 children.
+        assert len(result.get_children()) == 3 * len(totals.category)
+
+    @pytest.mark.parametrize(('minutes', 'expectation'), (
+        (1, '1 min'),
+        (30, '30 min'),
+        (59, '59 min'),
+        (60, '01:00'),
+        (300, '05:00'),
+    ))
+    def test__get_delta_string(self, charts, minutes, expectation):
+        delta = datetime.timedelta(minutes=minutes)
+        result = charts._get_delta_string(delta)
+        assert result == expectation
+
+
+class TestSummary(object):
+    """Unittests for Summery."""
+
+    def test_init(self, category_highest_totals):
+        """Test that instance meets expectation."""
+        result = overview.Summary(category_highest_totals)
+        assert isinstance(result, overview.Summary)
+        assert len(result.get_children()) == len(category_highest_totals)
+
+
+class TestHorizontalBarChart(object):
+    """Unittests for HorizontalBarChart."""
+
+    # [FIXME]
+    # Figure out a way to test the draw function properly.
+
+    def test_init(self, bar_chart_data):
+        """Make sure instance matches expectations."""
+        value, max_value = bar_chart_data
+        result = overview.HorizontalBarChart(value, max_value)
+        assert isinstance(result, overview.HorizontalBarChart)
+
+
+class TestDateRangeSelectDialog(object):
+    """Unittests for the daterange select dialog."""
+
+    def test_init(self, overview_screen):
+        assert overview.DateRangeSelectDialog(overview_screen)
+
+    def test_daterange_getter(self, daterange_select_dialog, daterange_parametrized):
+        """Make sure a tuple of start- end enddate is returned."""
+        start, end = daterange_parametrized
+        daterange_select_dialog._start_calendar.select_month(start.month - 1, start.year)
+        daterange_select_dialog._start_calendar.select_day(start.day)
+        daterange_select_dialog._end_calendar.select_month(end.month - 1, end.year)
+        daterange_select_dialog._end_calendar.select_day(end.day)
+        assert daterange_select_dialog.daterange == daterange_parametrized
+
+    def test_daterange_setter(self, daterange_select_dialog, daterange_parametrized):
+        """Make sure the correct start- and endtime is set on the calendars."""
+        start, end = daterange_parametrized
+        dialog = daterange_select_dialog
+        daterange_select_dialog.daterange = daterange_parametrized
+        assert helpers.calendar_date_to_datetime(dialog._start_calendar.get_date()) == start
+        assert helpers.calendar_date_to_datetime(dialog._end_calendar.get_date()) == end
+
+    def test__get_apply_button(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_apply_button()
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_today_widget(self, daterange_select_dialog, mocker):
+        """Make sure widget matches expectation."""
+        daterange_select_dialog._on_today_button_clicked = mocker.MagicMock()
+        result = daterange_select_dialog._get_today_widget()
+        result.emit('clicked')
+        assert daterange_select_dialog._on_today_button_clicked.called
+
+    def test__get_week_widget(self, daterange_select_dialog, mocker):
+        """Make sure widget matches expectation."""
+        daterange_select_dialog._on_week_button_clicked = mocker.MagicMock()
+        result = daterange_select_dialog._get_week_widget()
+        result.emit('clicked')
+        assert daterange_select_dialog._on_week_button_clicked.called
+
+    def test__get_month_widget(self, daterange_select_dialog, mocker):
+        """Make sure widget matches expectation."""
+        daterange_select_dialog._on_month_button_clicked = mocker.MagicMock()
+        result = daterange_select_dialog._get_month_widget()
+        result.emit('clicked')
+        assert daterange_select_dialog._on_month_button_clicked.called
+
+    def test__get_start_calendar(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_start_calendar()
+        assert isinstance(result, Gtk.Calendar)
+
+    def test__get_end_calendar(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_end_calendar()
+        assert isinstance(result, Gtk.Calendar)
+
+    def test__get_custom_range_label(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_custom_range_label()
+        assert isinstance(result, Gtk.Label)
+
+    def test__get_custom_range_connection_label(self, daterange_select_dialog):
+        """Make sure widget matches expectation."""
+        result = daterange_select_dialog._get_custom_range_connection_label()
+        assert isinstance(result, Gtk.Label)
+
+    def test__get_double_label_button(self, daterange_select_dialog, word_parametrized):
+        """Make sure widget matches expectation."""
+        l_label = word_parametrized
+        r_label = word_parametrized
+        result = daterange_select_dialog._get_double_label_button(l_label, r_label)
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_week_range(self, daterange_select_dialog, weekrange_parametrized):
+        """Make the right daterange is returned."""
+        date, expectation = weekrange_parametrized
+        result = daterange_select_dialog._get_week_range(date)
+        assert result == expectation
+
+    def test__get_month_range(self, daterange_select_dialog, monthrange_parametrized):
+        """Make the right daterange is returned."""
+        date, expectation = monthrange_parametrized
+        result = daterange_select_dialog._get_month_range(date)
+        assert result == expectation
+
+    @freeze_time('2016-04-01')
+    def test__on_today_button_clicked(self, daterange_select_dialog, mocker):
+        """Test that 'datetime' is set to today and right response is triggered."""
+        daterange_select_dialog.response = mocker.MagicMock()
+        daterange_select_dialog._on_today_button_clicked(None)
+        assert daterange_select_dialog.daterange == (datetime.date(2016, 4, 1),
+                                                     datetime.date(2016, 4, 1))
+        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)
+
+    @freeze_time('2016-04-01')
+    def test__on_week_button_clicked(self, daterange_select_dialog, mocker):
+        """Test that 'datetime' is set to 'this week' and right response is triggered."""
+        daterange_select_dialog.response = mocker.MagicMock()
+        daterange_select_dialog._on_week_button_clicked(None)
+        assert daterange_select_dialog.daterange == (datetime.date(2016, 3, 28),
+                                                     datetime.date(2016, 4, 3))
+        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)
+
+    @freeze_time('2016-04-01')
+    def test__on_month_button_clicked(self, daterange_select_dialog, mocker):
+        """Test that 'datetime' is set to 'this month' and right response is triggered."""
+        daterange_select_dialog.response = mocker.MagicMock()
+        daterange_select_dialog._on_month_button_clicked(None)
+        assert daterange_select_dialog.daterange == (datetime.date(2016, 4, 1),
+                                                     datetime.date(2016, 4, 30))
+        assert daterange_select_dialog.response.called_with(Gtk.ResponseType.APPLY)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+from gi.repository import Gtk
+from six import text_type
+
+from hamster_gtk.screens import tracking
+
+
+class TestTrackingScreen(object):
+    """Unittests for tracking screen."""
+
+    def test_init(self, app):
+        """Make sure instance matches expectation."""
+        result = tracking.TrackingScreen(app)
+        assert isinstance(result, tracking.TrackingScreen)
+        assert len(result.get_children()) == 2
+
+    def test_update_with_ongoing_fact(self, tracking_screen, fact, mocker):
+        """Make sure current fact view is shown."""
+        fact.end is None
+        tracking_screen.app.controler.store.facts.get_tmp_fact = mocker.MagicMock(
+            return_value=fact)
+        tracking_screen.update()
+        result = tracking_screen.get_visible_child()
+        assert result == tracking_screen.current_fact_view
+        assert isinstance(result, tracking.CurrentFactBox)
+
+    def test_update_with_no_ongoing_fact(self, tracking_screen, mocker):
+        """Make sure start tracking view is shown."""
+        tracking_screen.app.controler.store.facts.get_tmp_fact = mocker.MagicMock(
+            side_effect=KeyError)
+        tracking_screen.update()
+        result = tracking_screen.get_visible_child()
+        assert result == tracking_screen.start_tracking_view
+        assert isinstance(result, tracking.StartTrackingBox)
+
+
+class TestStartTrackingBox(object):
+    """Unittests for TrackingBox."""
+
+    def test_init(self, app):
+        """Make sure instances matches expectation."""
+        result = tracking.StartTrackingBox(app.controler)
+        assert isinstance(result, tracking.StartTrackingBox)
+        assert len(result.get_children()) == 3
+
+    def test__on_start_tracking_button(self, start_tracking_box, fact, mocker):
+        """Make sure a new 'ongoing fact' is created."""
+        # [FIXME]
+        # We need to find a viable way to check if signals are emitted!
+        start_tracking_box._controler.store.facts.save = mocker.MagicMock()
+        raw_fact = '{fact.activity.name}@{fact.category.name}'.format(fact=fact)
+        start_tracking_box.raw_fact_entry.props.text = raw_fact
+        start_tracking_box._on_start_tracking_button(None)
+        assert start_tracking_box._controler.store.facts.save.called
+
+    def test__reset(self, start_tracking_box):
+        """Make sure all relevant widgets are reset."""
+        start_tracking_box.raw_fact_entry.props.text = 'foobar'
+        start_tracking_box.reset()
+        assert start_tracking_box.raw_fact_entry.props.text == ''
+
+
+class TestCurrentFactBox(object):
+    """Unittests for CurrentFactBox."""
+
+    def test_init(self, app):
+        result = tracking.CurrentFactBox(app.controler)
+        assert isinstance(result, tracking.CurrentFactBox)
+
+    def test_update_initial_fact(self, current_fact_box, fact):
+        """Make sure update re-creates as widgets as expected."""
+        assert not current_fact_box.content.get_children()
+        current_fact_box.update(fact)
+        assert len(current_fact_box.content.get_children()) == 3
+        label = current_fact_box.content.get_children()[0]
+        expectation = '{activity.name}@{activity.category}'.format(activity=fact.activity)
+        assert expectation in label.get_text().decode('utf-8')
+
+    def test__get_fact_label(self, current_fact_box, fact):
+        """Make sure that the label matches expectations."""
+        result = current_fact_box._get_fact_label(fact)
+        assert isinstance(result, Gtk.Label)
+        assert result.get_text().decode('utf-8') == text_type(fact)
+
+    def test__get_cancel_button(self, current_fact_box):
+        """Make sure widget matches expectation."""
+        result = current_fact_box._get_cancel_button()
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_save_button(self, current_fact_box):
+        """Make sure widget matches expectation."""
+        result = current_fact_box._get_save_button()
+        assert isinstance(result, Gtk.Button)
+
+    def test__get_invalid_label(self, current_fact_box):
+        """Make sure widget matches expectation."""
+        result = current_fact_box._get_invalid_label()
+        assert isinstance(result, Gtk.Label)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pep257, docs, manifest
+envlist = flake8, pep257, manifest
 
 [testenv]
 sitepackages=True


### PR DESCRIPTION
This PR reduces the passing along of parent references. Instead we
focus on just passing 'app' or 'controler' references were needed.
With the exception of dialogs, most widgets can fetch their parents with
``self.get_parent``.
Because testing instantiation of all the widgets by hand became finally
unbearable we also add a rough shot at a basic testsuite. In cases were
we just check instantiation or  a 'get_widget_*' method our test usually
do not check for the widgets property right now but only whether or not
it successfully gets instantiated and matches the expected class.
While this maybe something that needs to be extended, this commit
provides a much needed infrastructure so that incremental improvements
can be done.

As of now, tox still shuts down with a segfault as soon any GTK class instantiated. On top of this travis segfaults on various tests (at least under py27). In order to limit the scope of this PR we left it at this for now.

A new command has been added to the makefile ``make codecov`` will compute and then upload a coverage report to codecov. Whilst not perfect this is at least one first shot until we get Travis working properly.