### PR TITLE
[#32] Wrap hamster-lib exceptions

### DIFF
--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -133,9 +133,19 @@ class OverviewDialog(Gtk.Dialog):
             self.show_all()
 
     def _get_facts(self):
-        """Collect and return all facts too be shown, not necessarily be visible."""
+        """
+        Collect and return all facts too be shown, not necessarily be visible.
+
+        A TypeError may indicated that the passed daterange istances may be of
+        invalid type. A ValueError that end is before start.
+        """
         start, end = self._daterange
-        return self._app.store.facts.get_all(start, end)
+        try:
+            result = self._app.store.facts.get_all(start, end)
+        except (TypeError, ValueError) as error:
+            helpers.show_error(self.get_toplevel(), error)
+        else:
+            return result
 
     def _group_facts(self):
         """

--- a/hamster_gtk/overview/widgets/fact_grid.py
+++ b/hamster_gtk/overview/widgets/fact_grid.py
@@ -123,9 +123,13 @@ class FactListBox(Gtk.ListBox):
 
     def _delete_fact(self, fact):
         """Delete fact from the backend. No further confirmation is required."""
-        result = self._controler.store.facts.remove(fact)
-        self._controler.signal_handler.emit('facts_changed')
-        return result
+        try:
+            result = self._controler.store.facts.remove(fact)
+        except (ValueError, KeyError) as error:
+            helpers.show_error(self.get_toplevel(), error)
+        else:
+            self._controler.signal_handler.emit('facts_changed')
+            return result
 
 
 class FactListRow(Gtk.ListBoxRow):

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -128,8 +128,12 @@ class CurrentFactBox(Gtk.Box):
 
         Discard current *ongoing fact* without saving.
         """
-        self._controler.store.facts.cancel_tmp_fact()
-        self.emit('tracking-stopped')
+        try:
+            self._controler.store.facts.cancel_tmp_fact()
+        except KeyError as err:
+            helpers.show_error(self.get_toplevel(), err)
+        else:
+            self.emit('tracking-stopped')
 
     def _on_save_button(self, button):
         """

--- a/tests/overview/test_dialogs.py
+++ b/tests/overview/test_dialogs.py
@@ -1,13 +1,29 @@
 # -*- coding: utf-8 -*-
 
 
+import pytest
+
+
 class TestOverviewDialog(object):
     """Unittests for the overview dialog."""
 
-    def test_daterange(self, request):
-        """Test that we return the right attribute."""
-        pass
+    def test__get_facts(self, request, overview_dialog, mocker):
+        """Make sure that daterange is considered when fetching facts."""
+        overview_dialog._app.store.facts.get_all = mocker.MagicMock()
+        overview_dialog._get_facts()
+        assert overview_dialog._app.store.facts.get_all.called_with(*overview_dialog._daterange)
 
-    def test_daterange_emit_signal(self, request):
-        """Test that setting a daterange emit the right signal."""
-        pass
+    @pytest.mark.parametrize('exception', (TypeError, ValueError))
+    def test__get_facts_handled_exception(self, request, overview_dialog, exception, mocker):
+        """Make sure that we show error dialog if we encounter an expected exception."""
+        overview_dialog._app.store.facts.get_all = mocker.MagicMock(side_effect=exception)
+        show_error = mocker.patch('hamster_gtk.overview.dialogs.helpers.show_error')
+        result = overview_dialog._get_facts()
+        assert result is None
+        assert show_error.called
+
+    def test__get_facts_unhandled_exception(self, request, overview_dialog, mocker):
+        """Make sure that we do not intercept unexpected exceptions."""
+        overview_dialog._app.store.facts.get_all = mocker.MagicMock(side_effect=Exception)
+        with pytest.raises(Exception):
+            overview_dialog._get_facts()

--- a/tests/overview/test_widgets.py
+++ b/tests/overview/test_widgets.py
@@ -60,6 +60,33 @@ class TestFactListBox(object):
         fact_list_box._on_activate(None, row)
         assert fact_list_box._update_fact.called
 
+    def test__delete_fact(self, request, fact_list_box, fact, mocker):
+        """Make sure that ``facts_changed`` signal is emitted."""
+        fact_list_box._controler.store.facts.remove = mocker.MagicMock()
+        fact_list_box.emit = mocker.MagicMock()
+        result = fact_list_box._delete_fact(fact)
+        assert fact_list_box._controler.store.facts.remove.called
+        assert result is result
+        assert fact_list_box.emit.called_with('facts_changed')
+
+    @pytest.mark.parametrize('exception', (KeyError, ValueError))
+    def test__delete_fact_expected_exception(self, request, fact_list_box, exception, fact,
+            mocker):
+        """Make sure that we show error dialog if we encounter an expected exception."""
+        fact_list_box._controler.store.facts.remove = mocker.MagicMock(side_effect=exception)
+        show_error = mocker.patch('hamster_gtk.overview.widgets.fact_grid.helpers.show_error')
+        fact_list_box.emit = mocker.MagicMock()
+        result = fact_list_box._delete_fact(fact)
+        assert result is None
+        assert show_error.called
+        assert fact_list_box.emit.called is False
+
+    def test__delete_fact_unexpected_exception(self, request, fact_list_box, fact, mocker):
+        """Make sure that we do not intercept unexpected exceptions."""
+        fact_list_box._controler.store.facts.remove = mocker.MagicMock(side_effect=Exception)
+        with pytest.raises(Exception):
+            fact_list_box._on_cancel_button(fact)
+
 
 class TestFactListRow(object):
     """Unittests for FactListRow."""


### PR DESCRIPTION
Calls to hamster-lib may raise exceptions to indicate an issue with the
passed arguments or database conflicts. Most of those 'expected
exceptions' should be handled gracefully by the frontend. Rightnow this
means to render them as a error message rather than stopping the
frontend from working.

Closes: #32