### PR TITLE
[#16] Add Preferencecs Dialog and Config Handling

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -22,18 +22,29 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import collections
+import datetime
+import os.path
 import traceback
 from gettext import gettext as _
 
 import gi
-import hamster_lib
 gi.require_version('Gdk', '3.0')  # NOQA
 gi.require_version('Gtk', '3.0')  # NOQA
+import hamster_lib
+# Once we drop py2 support, we can use the builtin again but unicode support
+# under python 2 is practically non existing and manual encoding is not easily
+# possible.
+from backports.configparser import SafeConfigParser
 from gi.repository import Gdk, GObject, Gtk
+from hamster_lib.helpers import config_helpers
+from six import text_type
 
+# [FIXME]
+# Remove once hamster-lib has been patched
+from hamster_gtk.helpers import _u, get_config_instance
 from hamster_gtk.overview import OverviewDialog
 from hamster_gtk.tracking import TrackingScreen
-from . import helpers
 
 
 APP_NAME = 'Hamster-GTK'
@@ -43,14 +54,17 @@ DEFAULT_WINDOW_SIZE = (400, 200)
 class HeaderBar(Gtk.HeaderBar):
     """Header bar for the main application window."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, app, *args, **kwargs):
         """Initialize header bar."""
         super(HeaderBar, self).__init__(*args, **kwargs)
+
+        self._app = app
 
         self.set_title(_("Hamster-GTK"))
         self.set_subtitle(_("Your friendly time tracker."))
         self.set_show_close_button(True)
 
+        self.pack_end(self._get_preferences_button())
         self.pack_end(self._get_overview_button())
 
     def _get_overview_button(self):
@@ -59,10 +73,31 @@ class HeaderBar(Gtk.HeaderBar):
         button.connect('clicked', self._on_overview_button)
         return button
 
+    def _get_preferences_button(self):
+        """Return a button to bring up the preferences dialog."""
+        button = Gtk.Button(_("Preferences"))
+        button.connect('clicked', self._on_preferences_button)
+        return button
+
     def _on_overview_button(self, button):
         """Callback for overview button."""
         parent = self.get_parent()
         OverviewDialog(parent, parent.app)
+
+    def _on_preferences_button(self, button):
+        """Bring up, process and shut down preferences dialog."""
+        def get_initial():
+            """Return current values as a dict."""
+            return self._app._config
+        parent = self.get_parent()
+        dialog = PreferencesDialog(parent, parent.app, get_initial())
+        response = dialog.run()
+        if response == Gtk.ResponseType.APPLY:
+            config = dialog.get_config()
+            self._app.save_config(config)
+        else:
+            pass
+        dialog.destroy()
 
 
 class MainWindow(Gtk.ApplicationWindow):
@@ -77,7 +112,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # Styling
         self.set_position(Gtk.WindowPosition.CENTER)
-        self.set_titlebar(HeaderBar())
+        self.set_titlebar(HeaderBar(self.app))
         self.set_default_size(*DEFAULT_WINDOW_SIZE)
 
         # Setup css
@@ -142,6 +177,8 @@ class MainWindow(Gtk.ApplicationWindow):
             """
 
 
+# [FIXME]
+# Its probably more sensible to just extend the app itself.
 class SignalHandler(GObject.GObject):
     """
     A simple signaling class. Use this to provide custom signal registration.
@@ -153,6 +190,7 @@ class SignalHandler(GObject.GObject):
     __gsignals__ = {
         str('facts-changed'): (GObject.SIGNAL_RUN_LAST, None, ()),
         str('daterange-changed'): (GObject.SIGNAL_RUN_LAST, None, (GObject.TYPE_PYOBJECT,)),
+        str('config-changed'): (GObject.SIGNAL_RUN_LAST, None, ()),
     }
 
     def __init__(self):
@@ -167,16 +205,35 @@ class HamsterGTK(Gtk.Application):
         """Setup instance and make sure default signals are connected to methods."""
         super(HamsterGTK, self).__init__()
         self.window = None
+        # Which config backend to use.
+        self.config_store = 'file'
+        self.config = self._reload_config()
 
         self.connect('startup', self._startup)
         self.connect('activate', self._activate)
         self.connect('shutdown', self._shutdown)
 
+    def save_config(self, config):
+        """
+        Save a potentially new/modified config instance to config backend.
+
+        Args:
+            config (dict): Dictionary of config keys and values.
+
+        Returns:
+            dict: Dictionary of config keys and values.
+        """
+        cp_instance = self._config_to_configparser(config)
+        config_helpers.write_config_file(cp_instance)
+        self.controler.signal_handler.emit('config-changed')
+
     def _startup(self, app):
         """Triggered right at startup."""
         print(_('Hamster-GTK started.'))  # NOQA
-        self.controler = hamster_lib.HamsterControl(helpers._get_config())
+        self._reload_config()
+        self.controler = hamster_lib.HamsterControl(self._config)
         self.controler.signal_handler = SignalHandler()
+        self.controler.signal_handler.connect('config-changed', self._reload_config)
         # For convenience only
         # [FIXME]
         # Pick one canonical path and stick to it!
@@ -203,6 +260,361 @@ class HamsterGTK(Gtk.Application):
     def _shutdown(self, app):
         """Triggered upon termination."""
         print('Hamster-GTK shut down.')  # NOQA
+
+    # We use sender=None for it to be called as a method as well.
+    def _reload_config(self, sender=None):
+        """Reload configuration from designated store."""
+        config = self._get_config_from_file()
+        self._config = config
+        return config
+
+    def _get_default_config(self):
+        """
+        Return a default config dictionary.
+
+        Note: Those defaults are independend of the particular config store.
+        """
+        appdirs = config_helpers.HamsterAppDirs('hamster-gtk')
+        return {
+            # Backend
+            'store': 'sqlalchemy',
+            'day_start': datetime.time(5, 30, 0),
+            'fact_min_delta': 1,
+            'tmpfile_path': os.path.join(appdirs.user_data_dir, 'hamster-gtk.tmp'),
+            'db_engine': 'sqlite',
+            'db_path': os.path.join(appdirs.user_data_dir, 'hamster-gtk.sqlite'),
+        }
+
+    def _config_to_configparser(self, config):
+        """
+        Return a ConfigParser instance representing a given config dictionary.
+
+        Args:
+            config (dict): Dictionary of config key/value pairs.
+
+        Returns:
+            SafeConfigParser: SafeConfigParser instance representing config.
+        """
+        def get_store():
+            return config['store']
+
+        def get_day_start():
+            return config['day_start'].strftime('%H:%M:%S')
+
+        def get_fact_min_delta():
+            return text_type(config['fact_min_delta'])
+
+        def get_tmpfile_path():
+            return text_type(config['tmpfile_path'])
+
+        def get_db_engine():
+            return config['db_engine']
+
+        def get_db_path():
+            return text_type(config['db_path'])
+
+        cp_instance = SafeConfigParser()
+        cp_instance.add_section('Backend')
+        cp_instance.set('Backend', 'store', get_store())
+        cp_instance.set('Backend', 'day_start', get_day_start())
+        cp_instance.set('Backend', 'fact_min_delta', get_fact_min_delta())
+        cp_instance.set('Backend', 'tmpfile_path', get_tmpfile_path())
+        cp_instance.set('Backend', 'db_engine', get_db_engine())
+        cp_instance.set('Backend', 'db_path', get_db_path())
+
+        return cp_instance
+
+    def _configparser_to_config(self, cp_instance):
+        """Return a config dict generate from a configparser nstance."""
+        def get_store():
+            store = cp_instance.get('Backend', 'store')
+            if store not in hamster_lib.REGISTERED_BACKENDS.keys():
+                raise ValueError(_("Unrecognized store option."))
+            return store
+
+        def get_day_start():
+            try:
+                day_start = datetime.datetime.strptime(cp_instance.get('Backend',
+                    'day_start'), '%H:%M:%S').time()
+            except ValueError:
+                raise ValueError(_(
+                    "We encountered an error when parsing configs 'day_start'"
+                    " value! Aborting ..."
+                ))
+            return day_start
+
+        def get_fact_min_delta():
+            return int(cp_instance.get('Backend', 'fact_min_delta'))
+
+        def get_tmpfile_path():
+            return cp_instance.get('Backend', 'tmpfile_path')
+
+        def get_db_config():
+            """Provide a dict with db-specifiy key/value to be added to the backend config."""
+            result = {}
+            engine = cp_instance.get('Backend', 'db_engine')
+            result = {'db_engine': engine}
+            if engine == 'sqlite':
+                result.update({'db_path': cp_instance.get('Backend', 'db_path')})
+            else:
+                try:
+                    result.update({'db_port': cp_instance.get('Backend', 'db_port')})
+                except KeyError:
+                    # Thats alright, the backend will use the default port.
+                    pass
+
+                result.update({
+                    'db_host': cp_instance.get('Backend', 'db_host'),
+                    'db_name': cp_instance.get('Backend', 'db_name'),
+                    'db_user': cp_instance.get('Backend', 'db_user'),
+                    'db_password': cp_instance.get('Backend', 'db_password'),
+                })
+            return result
+
+        result = {
+            'store': get_store(),
+            'day_start': get_day_start(),
+            'fact_min_delta': get_fact_min_delta(),
+            'tmpfile_path': get_tmpfile_path(),
+        }
+        result.update(get_db_config())
+        return result
+
+    def _write_config_to_file(self, configparser_instance):
+        """
+        Write a configparser instance to a config file.
+
+        Args:
+            cp_instance (SafeConfigParser): Instance to be written to file.
+        """
+        config_helpers.write_config_file(configparser_instance, 'hamster-gtk', 'hamster-gtk.conf')
+
+    def _get_config_from_file(self):
+        """
+        Return a config dictionary from acp_instanceg file.
+
+        If there is none create a default config file. This methods main job is
+        to convert strings from the loaded ConfigParser File to appropiate
+        instances suitable for our config dictionary. The actual data retrival
+        is provided by a hamster-lib helper function.
+
+        Returns:
+            dict: Dictionary of config key/values.
+        """
+        def get_fallback():
+            config = self._get_default_config()
+            return self._config_to_configparser(config)
+
+        cp_instance = get_config_instance(get_fallback(), 'hamster-gtk', 'hamster-gtk.conf')
+        return self._configparser_to_config(cp_instance)
+
+
+class PreferencesDialog(Gtk.Dialog):
+    """A dialog that shows and allows editing of config settings."""
+
+    def __init__(self, parent, app, initial, *args, **kwargs):
+        """
+        Instantiate dialog.
+
+        Args:
+            parent (Gtk.Window): Diaog parent.
+            app (HamsterGTK): Main app instance. Needed in order to retrieve
+                and manipulate config values.
+        """
+        super(PreferencesDialog, self).__init__(*args, **kwargs)
+
+        self._parent = parent
+        self._app = app
+
+        self.set_transient_for(self._parent)
+
+        # We use an ordered dict as the order reflects display order as well.
+        self._fields = collections.OrderedDict([
+            ('store', self._get_store_widget(initial=initial['store'])),
+            ('day_start', self._get_day_start_widget(initial=initial['day_start'])),
+            ('fact_min_delta', self._get_fact_min_delta_widget(initial=initial['fact_min_delta'])),
+            ('tmpfile_path', self._get_tmpfile_path_widget(initial=initial['tmpfile_path'])),
+            ('db_engine', self._get_db_engine_widget(initial=initial['db_engine'])),
+            ('db_path', self._get_db_path_widget(initial=initial['db_path'])),
+        ])
+
+        grid = Gtk.Grid()
+        grid.set_hexpand(True)
+        row = 0
+        for key, widgets in self._fields.items():
+            label, widget = widgets
+            grid.attach(label, 0, row, 1, 1)
+            grid.attach(widget, 1, row, 1, 1)
+            row += 1
+
+        self.get_content_area().add(grid)
+        self.add_action_widget(self._get_cancel_button(), Gtk.ResponseType.CANCEL)
+        self.add_action_widget(self._get_apply_button(), Gtk.ResponseType.APPLY)
+
+        self.show_all()
+
+    def get_config(self):
+        """Parse config widgets and construct a {field: value} dict."""
+        def get_string(widget):
+            if isinstance(widget, Gtk.Entry):
+                result = _u(widget.get_text())
+            elif isinstance(widget, Gtk.ComboBoxText):
+                index = widget.get_active()
+                result = widget.options[index]
+            elif isinstance(widget, Gtk.Grid):
+                result = _u(widget.entry.get_text())
+            else:
+                raise TypeError(_("Unhandled widget class!"))
+            return result
+
+        def get_time(widget):
+            if isinstance(widget, Gtk.Entry):
+                result = _u(widget.get_text())
+                # We are tollerant against malformed time information.
+                try:
+                    result = datetime.datetime.strptime(result, '%H:%M:%S').time()
+                except ValueError:
+                    result = datetime.datetime.strptime(result, '%H:%M').time()
+            else:
+                raise TypeError(_("Unhandled widget class!"))
+            return result
+
+        def get_int(widget):
+            string = get_string(widget)
+            result = None
+            if string:
+                result = int(string)
+            return result
+
+        string_fields = ('store', 'tmpfile_path', 'db_engine', 'db_path')
+        time_fields = ('day_start',)
+        int_fields = ('fact_min_delta',)
+
+        result = {}
+        for key in string_fields:
+            label, widget = self._fields[key]
+            result[key] = get_string(widget)
+
+        for key in time_fields:
+            label, widget = self._fields[key]
+            result[key] = get_time(widget)
+
+        for key in int_fields:
+            label, widget = self._fields[key]
+            result[key] = get_int(widget)
+        return result
+
+    # Widgets
+    def _get_apply_button(self):
+        """Return a *apply* button."""
+        return Gtk.Button.new_from_stock(Gtk.STOCK_APPLY)
+
+    def _get_cancel_button(self):
+        """Return a *cancel* button."""
+        return Gtk.Button.new_from_stock(Gtk.STOCK_CANCEL)
+
+    def _get_store_widget(self, initial=None):
+        """Return widget to set the backend store."""
+        label = Gtk.Label(_("Store"))
+        widget = Gtk.ComboBoxText()
+        # It seems Gtk.ComboBox provides no easy access to its stored options
+        # that would allow getting their index. The index however is needed in
+        # order to programmatically set an option. Until we find a better
+        # solution we need to keep our own 'string-to-index' mapping.
+        # We create a immutable duplicate of the original store list in order
+        # to prevent accidental side effects and changes to the list effecting
+        # the combobox index.
+        widget.options = tuple(hamster_lib.REGISTERED_BACKENDS.keys())
+        for store in hamster_lib.REGISTERED_BACKENDS.values():
+            widget.append_text(store.verbose_name)
+        if initial:
+            widget.set_active(widget.options.index(initial))
+        return (label, widget)
+
+    def _get_day_start_widget(self, initial=None):
+        """Return widget to set the *day start* value."""
+        label_text = "{} (HH:MM:SS)".format(_("Day Start"))
+        label = Gtk.Label(label_text)
+        widget = Gtk.Entry()
+        # We need to be explicit about 'None'. A bool(datetime.time(0, 0, 0))
+        # evaluates to False and as a consequence would not trigger the setting
+        # of the initial value.
+        if initial is not None:
+            widget.set_text(text_type(initial.strftime('%H:%M:%S')))
+        return (label, widget)
+
+    def _get_fact_min_delta_widget(self, initial=None):
+        """Return widget to set the minimum duration for a fact."""
+        label = Gtk.Label(_("Minimal Fact Duration"))
+        widget = Gtk.Entry()
+        # We need to check for None in order to allow 0 as initial value.
+        if initial is not None:
+            widget.set_text(text_type(int(initial)))
+        return (label, widget)
+
+    def _get_tmpfile_path_widget(self, initial=None):
+        """Return widget to set the location to save the tmp fact."""
+        label = Gtk.Label(_("Full 'tmpfile'-path"))
+        grid = self._get_path_entry_with_button(initial,
+            self._on_tmpfile_path_choose_button_clicked)
+        return (label, grid)
+
+    def _get_db_engine_widget(self, initial=None):
+        """Return widget to specify the *db-engine* value."""
+        label = Gtk.Label(_("DB Engine"))
+        widget = Gtk.ComboBoxText()
+        widget.options = ('sqlite', 'postgresql', 'mysql', 'oracle', 'mssql')
+        for engine in widget.options:
+            widget.append_text(engine)
+        if initial:
+            widget.set_active(widget.options.index(initial))
+        return (label, widget)
+
+    def _get_db_path_widget(self, initial=None):
+        """Return a widget to specify the *db-path*."""
+        label = Gtk.Label(_("DB Path"))
+        grid = self._get_path_entry_with_button(initial,
+            self._on_db_path_choose_button_clicked)
+        return (label, grid)
+
+    # Callbacks
+    def _on_tmpfile_path_choose_button_clicked(self, button):
+        """Open a dialog to select path."""
+        self._update_entry_via_filechooser('tmpfile_path')
+
+    def _on_db_path_choose_button_clicked(self, button):
+        """Open a dialog to select path."""
+        self._update_entry_via_filechooser('db_path')
+
+    # Helpers
+    def _update_entry_via_filechooser(self, fieldname):
+        """Open a dialog to select path and update entry widget with it."""
+        def update_entry(new_path):
+            entry = self._fields[fieldname][1].entry
+            entry.set_text(text_type(new_path))
+        dialog = Gtk.FileChooserDialog(_("Please choose a directory"), self,
+            Gtk.FileChooserAction.SAVE, (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                                         Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+        response = dialog.run()
+        if response == Gtk.ResponseType.OK:
+            update_entry(dialog.get_filename())
+        else:
+            pass
+        dialog.destroy()
+
+    def _get_path_entry_with_button(self, initial, callback):
+        """Return a path entry field with accompanying button."""
+        entry = Gtk.Entry()
+        entry.set_hexpand(True)
+        button = Gtk.Button(_("Choose"))
+        button.connect('clicked', callback)
+        grid = Gtk.Grid()
+        grid.entry = entry
+        grid.attach(entry, 0, 0, 1, 1)
+        grid.attach(button, 1, 0, 1, 1)
+        if initial:
+            entry.set_text(text_type(initial))
+        return grid
 
 
 def _main():

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -21,23 +21,35 @@
 
 import datetime
 
+import six
+
 from . import dialogs
 
 
-def _get_config():
+def _u(string):
     """
-    Get config to be passed to controler.
+    Return passed string as a text instance.
 
-    For now this is just a dummy/mock.
+    This helper is particularly useful to wrap Gtk 'string return values' as
+    they depend on the used python version. On python 2 Gtk will return utf-8
+    encoded bytestrings while on python 3 it will return 'unicode strings'.
+
+    The reason we have to use this and not ``six.u`` is that six does not make
+    assumptions about the encoding and hence can not be used to safely decode
+    non ascii bytestrings into unicode.
+
+    Args:
+        string (str): A string instance. On ``py2`` this will be a bytestring,
+            on ``py3`` a 'unicode string'.
+
+    Returns:
+        text_type: Returns a 'unicode text type'. Under ``py2`` that means a
+        ``unicode`` instance, under ``py3`` this will be a ``str`` instance.
     """
-    return {
-        'store': 'sqlalchemy',
-        'day_start': datetime.time(5, 30, 0),
-        'fact_min_delta': 1,
-        'tmpfile_path': '/tmp/tmpfile.pickle',
-        'db_engine': 'sqlite',
-        'db_path': '/tmp/hamster.sqlite',
-    }
+    if six.PY2:
+        return string.decode('utf-8')
+    else:
+        return string
 
 
 def show_error(parent, error, message=None):
@@ -80,3 +92,19 @@ def calendar_date_to_datetime(date):
     """Convert :meth:`Gtk.Calendar.get_date` value to :class:`datetime.date`."""
     year, month, day = date
     return datetime.date(int(year), int(month) + 1, int(day))
+
+
+# [FIXME]
+# Remove once hamster-lib is patched
+# This should probablyy be named/limited to: 'read_config_file'.
+# The 'fallback' behaviour should live with ``_get_config_from_file``.
+def get_config_instance(fallback_config_instance, app_name, file_name):
+    """Patched version of ``hamster-lib`` helper function until it get fixed upstream."""
+    from hamster_lib.helpers import config_helpers
+    from backports.configparser import SafeConfigParser
+    config = SafeConfigParser()
+    path = config_helpers.get_config_path(app_name)
+    if not config.read(path):
+        config = config_helpers.write_config_file(fallback_config_instance, app_name,
+                                                  file_name=file_name)
+    return config

--- a/hamster_gtk/misc/__init__.py
+++ b/hamster_gtk/misc/__init__.py
@@ -17,4 +17,6 @@
 
 """This module provides several multi purpose dialoges and widgets."""
 
-from dialogs import DateRangeSelectDialog, EditFactDialog, ErrorDialog  # NOQA
+from __future__ import absolute_import, unicode_literals
+
+from .dialogs import DateRangeSelectDialog, EditFactDialog, ErrorDialog  # NOQA

--- a/hamster_gtk/misc/dialogs.py
+++ b/hamster_gtk/misc/dialogs.py
@@ -33,6 +33,7 @@ from hamster_lib import Fact
 from six import text_type
 
 from hamster_gtk import helpers
+from hamster_gtk.helpers import _u
 
 
 class ErrorDialog(Gtk.MessageDialog):
@@ -261,14 +262,14 @@ class EditFactDialog(Gtk.Dialog):
         """Fact instance using values at the time of accessing it."""
         def get_raw_fact_value():
             """Get text from raw fact entry field."""
-            return self._raw_fact_widget.get_text().decode('utf-8')
+            return _u(self._raw_fact_widget.get_text())
 
         def get_description_value():
             """Get unicode value from widget."""
             text_view = self._description_widget.get_child()
             text_buffer = text_view.get_buffer()
             start, end = text_buffer.get_bounds()
-            return text_buffer.get_text(start, end, True).decode('utf-8')
+            return _u(text_buffer.get_text(start, end, True))
 
         # Create a new fact instance from the provided raw string.
         fact = Fact.create_from_raw_fact(get_raw_fact_value())

--- a/hamster_gtk/tracking/__init__.py
+++ b/hamster_gtk/tracking/__init__.py
@@ -17,4 +17,6 @@
 
 """This sub module provides class suitable to track the 'ongoing fact'."""
 
-from .sceens import TrackingScreen  # NOQA
+from __future__ import absolute_import, unicode_literals
+
+from .screens import TrackingScreen  # NOQA

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -27,6 +27,7 @@ from gettext import gettext as _
 
 from gi.repository import GObject, Gtk
 from hamster_lib import Fact
+from hamster_gtk.helpers import _u
 
 import hamster_gtk.helpers as helpers
 
@@ -204,7 +205,7 @@ class StartTrackingBox(Gtk.Box):
             fact.end = None
             return fact
 
-        raw_fact = self.raw_fact_entry.props.text.decode('utf-8')
+        raw_fact = _u(self.raw_fact_entry.props.text)
 
         try:
             fact = Fact.create_from_raw_fact(raw_fact)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ source = hamster_gtk
 
 [isort]
 not_skip = __init__.py
-known_third_party = faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
-    past, pytest, pytest_factoryboy
+known_third_party = backports, faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
+    past, pytest, pytest_factoryboy, six
 
 [pytest]
 addopt =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,29 @@
 
 """Unittest fixtures."""
 
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+
 import fauxfactory
 import pytest
 from gi.repository import Gtk
+from hamster_lib.helpers.config_helpers import HamsterAppDirs
 from pytest_factoryboy import register
 
-import factories
-import hamster_gtk.hamster_gtk as hamster_gtk
+from hamster_gtk import hamster_gtk
+
+from . import factories
 
 register(factories.CategoryFactory)
 register(factories.ActivityFactory)
 register(factories.FactFactory)
+
+
+@pytest.fixture
+def appdirs(request):
+    """Return HamsterAppDirs instance."""
+    return HamsterAppDirs('hamster-gtk')
 
 
 # Instances
@@ -35,14 +47,14 @@ def main_window(request, app):
 
 
 @pytest.fixture
-def header_bar(request):
+def header_bar(request, app):
     """
     Return a HeaderBar instance.
 
     Note:
         This instance has not been added to any parent window yet!
     """
-    return hamster_gtk.HeaderBar()
+    return hamster_gtk.HeaderBar(app)
 
 
 @pytest.fixture
@@ -54,6 +66,12 @@ def dummy_window(request):
     functionality.
     """
     return Gtk.Window()
+
+
+@pytest.fixture
+def preferences_dialog(request, dummy_window, app, config):
+    """Return plain PreferencesDialog instance."""
+    return hamster_gtk.PreferencesDialog(dummy_window, app, config)
 
 
 @pytest.fixture(params=(
@@ -77,3 +95,85 @@ def facts_grouped_by_date(request, fact_factory):
 def set_of_facts(request, fact_factory):
     """Provide a set of randomized fact instances."""
     return fact_factory.build_batch(5)
+
+
+@pytest.fixture
+def config(request, tmpdir):
+    """Return a dict of config keys and values."""
+    config = {
+        'store': 'sqlalchemy',
+        'day_start': datetime.time(5, 30, 0),
+        'fact_min_delta': 1,
+        'tmpfile_path': tmpdir.join('tmpfile.hamster'),
+        'db_engine': 'sqlite',
+        'db_path': ':memory:',
+    }
+    return config
+
+
+@pytest.fixture(params=('sqlalchemy',))
+def store_parametrized(request):
+    """Return a parametrized store value."""
+    return request.param
+
+
+@pytest.fixture(params=(
+    datetime.time(0, 0, 0),
+    datetime.time(5, 30, 0),
+    datetime.time(17, 22, 0),
+))
+def day_start_parametrized(request):
+    """Return a parametrized day_start value."""
+    return request.param
+
+
+@pytest.fixture(params=(0, 1, 30, 60))
+def fact_min_delta_parametrized(request):
+    """Return a parametrized fact_min_delta value."""
+    return request.param
+
+
+@pytest.fixture(params=(
+    fauxfactory.gen_utf8(),
+    fauxfactory.gen_latin1(),
+))
+def tmpfile_path_parametrized(request, tmpdir):
+    """Return a parametrized tmpfile_path value."""
+    return tmpdir.mkdir(request.param).join('tmpfile.hamster')
+
+
+@pytest.fixture(params=(
+    'sqlite',
+))
+def db_engine_parametrized(request):
+    """Return a parametrized db_engine value."""
+    return request.param
+
+
+@pytest.fixture(params=(
+    fauxfactory.gen_utf8(),
+    fauxfactory.gen_latin1(),
+    ':memory:',
+))
+def db_path_parametrized(request, tmpdir):
+    """Return a parametrized db_path value."""
+    if not request.param == ':memory:':
+        path = tmpdir.mkdir(request.param).join('hamster.file')
+    else:
+        path = request.param
+    return path
+
+
+@pytest.fixture
+def initial_config_parametrized(request, store_parametrized, day_start_parametrized,
+        fact_min_delta_parametrized, tmpfile_path_parametrized, db_engine_parametrized,
+        db_path_parametrized):
+            """Return a config fixture with heavily parametrized config values."""
+            return {
+                'store': store_parametrized,
+                'day_start': day_start_parametrized,
+                'fact_min_delta': fact_min_delta_parametrized,
+                'tmpfile_path': tmpfile_path_parametrized,
+                'db_engine': db_engine_parametrized,
+                'db_path': db_path_parametrized,
+            }

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -2,10 +2,13 @@
 
 from __future__ import unicode_literals
 
+import datetime
+import os.path
+
 from gi.repository import Gtk
 from six import text_type
 
-from hamster_gtk import hamster_gtk
+import hamster_gtk.hamster_gtk as hamster_gtk
 from hamster_gtk.tracking import TrackingScreen
 
 
@@ -16,6 +19,46 @@ class TestHamsterGTK(object):
         """Make sure class instatiation works as intended."""
         app = hamster_gtk.HamsterGTK()
         assert app
+
+    def test__reload_config(self, app, config, mocker):
+        """Make sure a config is retrieved and stored as instance attribute."""
+        app._get_config_from_file = mocker.MagicMock(return_value=config)
+        result = app._reload_config()
+        assert result == config
+        assert app._config == config
+
+    def test__get_default_config(self, app, appdirs):
+        """Make sure the defaults use appdirs for relevant paths."""
+        result = app._get_default_config()
+        assert len(result) == 6
+        assert os.path.dirname(result['tmpfile_path']) == appdirs.user_data_dir
+        assert os.path.dirname(result['db_path']) == appdirs.user_data_dir
+
+    def test__config_to_configparser(self, app, config):
+        """Make sure conversion of a config dictionary matches expectations."""
+        result = app._config_to_configparser(config)
+        assert result.get('Backend', 'store') == config['store']
+        assert datetime.datetime.strptime(
+            result.get('Backend', 'day_start'), '%H:%M:%S'
+        ).time() == config['day_start']
+        assert int(result.get('Backend', 'fact_min_delta')) == config['fact_min_delta']
+        assert result.get('Backend', 'tmpfile_path') == config['tmpfile_path']
+        assert result.get('Backend', 'db_engine') == config['db_engine']
+        assert result.get('Backend', 'db_path') == config['db_path']
+
+    def test__get_configparser_to_config(self, app, config):
+        """Make sure conversion works as expected."""
+        # [FIXME]
+        # Maybe we find a better way to do this?
+        cp_instance = app._config_to_configparser(config)
+        result = app._configparser_to_config(cp_instance)
+        assert result['store'] == cp_instance.get('Backend', 'store')
+        assert result['day_start'] == datetime.datetime.strptime(
+            cp_instance.get('Backend', 'day_start'), '%H:%M:%S').time()
+        assert result['fact_min_delta'] == int(cp_instance.get('Backend', 'fact_min_delta'))
+        assert result['tmpfile_path'] == cp_instance.get('Backend', 'tmpfile_path')
+        assert result['db_engine'] == cp_instance.get('Backend', 'db_engine')
+        assert result['db_path'] == cp_instance.get('Backend', 'db_path')
 
 
 class TestMainWindow(object):
@@ -41,9 +84,9 @@ class TestHeaderBar(object):
         assert header_bar.props.title == 'Hamster-GTK'
         assert header_bar.props.subtitle == 'Your friendly time tracker.'
         assert header_bar.props.show_close_button
-        assert len(header_bar.get_children()) == 1
+        assert len(header_bar.get_children()) == 2
 
-    def test__get_oheader_barview_button(self, header_bar, mocker):
+    def test__get_overview_button(self, header_bar, mocker):
         """Test that that button returned matches expectation."""
         header_bar._on_overview_button = mocker.MagicMock()
         result = header_bar._get_overview_button()
@@ -57,3 +100,80 @@ class TestHeaderBar(object):
         overview_class = mocker.patch('hamster_gtk.hamster_gtk.OverviewDialog')
         bar._on_overview_button(None)
         assert overview_class.called
+
+    def test__get_preferences_button(self, header_bar, mocker):
+        """Test that that button returned matches expectation."""
+        header_bar._on_preferences_button = mocker.MagicMock()
+        result = header_bar._get_preferences_button()
+        assert isinstance(result, Gtk.Button)
+        result.emit('clicked')
+        assert header_bar._on_preferences_button.called
+
+    def test__on_preferences_button_apply(self, main_window, mocker):
+        """Make sure a preference dialog is created."""
+        bar = main_window.get_titlebar()
+        preferences_class = mocker.patch('hamster_gtk.hamster_gtk.PreferencesDialog')
+        mocker.patch('hamster_gtk.hamster_gtk.PreferencesDialog.run',
+            return_value=Gtk.ResponseType.APPLY)
+        bar._app.save_config = mocker.MagicMock()
+        bar._on_preferences_button(None)
+        assert preferences_class.called
+        bar._app.save_config.called
+
+
+class TestPreferencesDialog(object):
+    """Unittests for PreferencesDialog."""
+
+    def test_init(self, dummy_window, app, config):
+        """Make instantiation works as expected."""
+        result = hamster_gtk.PreferencesDialog(dummy_window, app, config)
+        grid = result.get_content_area().get_children()[0]
+        # This assumes 2 children per config entry (label and widget).
+        assert len(grid.get_children()) / 2 == len(config.keys())
+
+    def test_get_config(self, dummy_window, app, initial_config_parametrized):
+        """
+        Make sure retrieval of field values works as expected.
+
+        In particular we need to make sure that unicode/utf-8 handling works as
+        expected.
+        """
+        dialog = hamster_gtk.PreferencesDialog(dummy_window, app, initial_config_parametrized)
+        result = dialog.get_config()
+        assert result == initial_config_parametrized
+
+    def test_get_store_widget(self, preferences_dialog):
+        """Make sure widgets match expectation."""
+        label, widget = preferences_dialog._get_store_widget()
+        assert isinstance(label, Gtk.Label)
+        assert isinstance(widget, Gtk.ComboBoxText)
+
+    def test_get_day_start_widget(self, preferences_dialog):
+        """Make sure widgets match expectation."""
+        label, widget = preferences_dialog._get_day_start_widget()
+        assert isinstance(label, Gtk.Label)
+        assert isinstance(widget, Gtk.Entry)
+
+    def test_get_fact_min_delta_widget(self, preferences_dialog):
+        """Make sure widgets match expectation."""
+        label, widget = preferences_dialog._get_fact_min_delta_widget()
+        assert isinstance(label, Gtk.Label)
+        assert isinstance(widget, Gtk.Entry)
+
+    def test_get_tmpfile_path_widget(self, preferences_dialog):
+        """Make sure widgets match expectation."""
+        label, widget = preferences_dialog._get_tmpfile_path_widget()
+        assert isinstance(label, Gtk.Label)
+        assert isinstance(widget, Gtk.Grid)
+
+    def test_get_db_engine_widget(self, preferences_dialog):
+        """Make sure widgets match expectation."""
+        label, widget = preferences_dialog._get_db_engine_widget()
+        assert isinstance(label, Gtk.Label)
+        assert isinstance(widget, Gtk.ComboBoxText)
+
+    def test_get_db_path_widget(self, preferences_dialog):
+        """Make sure widgets match expectation."""
+        label, widget = preferences_dialog._get_db_path_widget()
+        assert isinstance(label, Gtk.Label)
+        assert isinstance(widget, Gtk.Grid)

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk
 from six import text_type
 import pytest
 
+from hamster_gtk.helpers import _u
 from hamster_gtk.tracking import screens
 
 
@@ -78,13 +79,13 @@ class TestCurrentFactBox(object):
         assert len(current_fact_box.content.get_children()) == 3
         label = current_fact_box.content.get_children()[0]
         expectation = '{activity.name}@{activity.category}'.format(activity=fact.activity)
-        assert expectation in label.get_text().decode('utf-8')
+        assert expectation in _u(label.get_text())
 
     def test__get_fact_label(self, current_fact_box, fact):
         """Make sure that the label matches expectations."""
         result = current_fact_box._get_fact_label(fact)
         assert isinstance(result, Gtk.Label)
-        assert result.get_text().decode('utf-8') == text_type(fact)
+        assert _u(result.get_text()) == text_type(fact)
 
     def test__get_cancel_button(self, current_fact_box):
         """Make sure widget matches expectation."""


### PR DESCRIPTION
This commit introduces a basic preference dialog as well as basic
infrastructure to handle configuration.
A new ``config-changed`` signal has been added to the main signal
handler that is emitted whenever changes to the config are made in order
to trigger their reload.
Internally, configuration is stored as the ``HamsterGTK._config``
attribute to the main application as dictionary of config keys and
values.
Whilst in future we want to support additional config stores (GConf
comes to mind) we limit ourselfs to using ConfigParser to use config
files stored to disk. In order to do so we utilize
``hamster_lib.helpers.config_helpers`` to deal with actually reading and
writing the file. That leaves implementing methods to convert config
data between the internal config dictionary and the configparser
instance. While doing so some extra work is performed because dictionary
values are properly typed (datetime, int, etc...) while the configparser
instance only deals with strings.

In case no config file can be found, we also provide a default config.

When dealing with GTK widgets we decoded them with utf-8 as they are
returned as 'byte-strings'. This obiously led to issues under python 3
where they are returned as 'unicode text strings' and no ``decode``
method is applicable. We added a custom helper method ``_u`` that will
decode a passed ``str`` instance with utf-8 under py2 and just return
the
string under py3. Unfortunatly we were unable to use six.u for this as
it is not safe for non ascii chars (it does not make our assumptins
about the input strings encoding).

Closes: #16 #20