### PR TITLE
[#40] Add very basic export capabilities

### DIFF
--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -35,6 +35,7 @@ import operator
 from collections import defaultdict, namedtuple
 
 from gi.repository import Gtk
+from hamster_lib import reports
 
 from . import widgets
 from .. import helpers
@@ -132,6 +133,9 @@ class OverviewDialog(Gtk.Dialog):
             self.main_box.pack_start(self._charts, False, False, 0)
             self.show_all()
 
+    # [FIXME]
+    # To avoid multiple falls to the backend, maybe some rudimentaty chaching
+    # would be sensible.
     def _get_facts(self):
         """
         Collect and return all facts too be shown, not necessarily be visible.
@@ -231,6 +235,16 @@ class OverviewDialog(Gtk.Dialog):
         orig_start, orig_end = self._daterange
         offset = (orig_end - orig_start) + datetime.timedelta(days=1)
         self._daterange = (orig_start + offset, orig_end + offset)
+
+    def _export_facts(self, target_path):
+        """
+        Export current set of facts to file.
+
+        Args:
+            target_path (text_type): Location to export to.
+        """
+        writer = reports.TSVWriter(target_path)
+        writer.write_report(self._get_facts())
 
     # Widgets
     def _get_summery_widget(self, category_totals):

--- a/hamster_gtk/overview/widgets/misc.py
+++ b/hamster_gtk/overview/widgets/misc.py
@@ -39,10 +39,17 @@ class HeaderBar(Gtk.HeaderBar):
         self.pack_start(self._get_prev_daterange_button())
         self.pack_start(self._get_next_daterange_button())
         self.pack_start(self._daterange_button)
+        self.pack_end(self._get_export_button())
 
         controler.signal_handler.connect('daterange-changed', self._on_daterange_changed)
 
     # Widgets
+    def _get_export_button(self):
+        """Return a button to export facts."""
+        button = Gtk.Button(_("Export"))
+        button.connect('clicked', self._on_export_button_clicked)
+        return button
+
     def _get_daterange_button(self):
         """Return a button that opens the *select daterange* dialog."""
         # We add a dummy label which will be set properly once a daterange is
@@ -91,6 +98,26 @@ class HeaderBar(Gtk.HeaderBar):
     def _on_next_daterange_button_clicked(self, button):
         """Callback for when the 'next' button is clicked."""
         self.get_parent().apply_next_daterange()
+
+    def _on_export_button_clicked(self, button):
+        """
+        Trigger fact export if button clicked.
+
+        This is the place to run extra logic about where to save/which format.
+        ``parent._export_facts`` only deals with the actual export.
+        """
+        parent = self.get_parent()
+        dialog = Gtk.FileChooserDialog(_("Please Choose where to export to"), parent,
+            Gtk.FileChooserAction.SAVE, (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                                         Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+        dialog.set_current_name('{}.csv'.format(_("hamster_export")))
+        response = dialog.run()
+        if response == Gtk.ResponseType.OK:
+            target_path = dialog.get_filename()
+            parent._export_facts(target_path)
+        else:
+            pass
+        dialog.destroy()
 
 
 class Summary(Gtk.Box):

--- a/tests/overview/test_dialogs.py
+++ b/tests/overview/test_dialogs.py
@@ -7,14 +7,14 @@ import pytest
 class TestOverviewDialog(object):
     """Unittests for the overview dialog."""
 
-    def test__get_facts(self, request, overview_dialog, mocker):
+    def test__get_facts(self, overview_dialog, mocker):
         """Make sure that daterange is considered when fetching facts."""
         overview_dialog._app.store.facts.get_all = mocker.MagicMock()
         overview_dialog._get_facts()
         assert overview_dialog._app.store.facts.get_all.called_with(*overview_dialog._daterange)
 
     @pytest.mark.parametrize('exception', (TypeError, ValueError))
-    def test__get_facts_handled_exception(self, request, overview_dialog, exception, mocker):
+    def test__get_facts_handled_exception(self, overview_dialog, exception, mocker):
         """Make sure that we show error dialog if we encounter an expected exception."""
         overview_dialog._app.store.facts.get_all = mocker.MagicMock(side_effect=exception)
         show_error = mocker.patch('hamster_gtk.overview.dialogs.helpers.show_error')
@@ -22,8 +22,25 @@ class TestOverviewDialog(object):
         assert result is None
         assert show_error.called
 
-    def test__get_facts_unhandled_exception(self, request, overview_dialog, mocker):
+    def test__get_facts_unhandled_exception(self, overview_dialog, mocker):
         """Make sure that we do not intercept unexpected exceptions."""
         overview_dialog._app.store.facts.get_all = mocker.MagicMock(side_effect=Exception)
         with pytest.raises(Exception):
             overview_dialog._get_facts()
+
+    # [FIXME]
+    # It is probably good to also have a more comprehensive test that actually
+    # checks if a file with particular content is written.
+    def test__export_facts(self, overview_dialog, tmpdir, mocker):
+        """
+        Make sure the proper report class is instantiated and writter.
+
+        With all its mocks this test is not the best one imageinable, but as
+        the method will change rapidly soon this does for now.
+        """
+        writer = mocker.patch('hamster_gtk.overview.dialogs.reports.TSVWriter')
+        overview_dialog._get_facts = mocker.MagicMock(return_value={})
+        result = overview_dialog._export_facts(tmpdir.strpath)
+        assert result is None
+        assert writer.called
+        assert overview_dialog._get_facts.called


### PR DESCRIPTION
This commits add a very basic way to export facts to file.
This is done via the overview dialog. The idea is that the generic
overview functionality will be used to select the relevant facts.

Closes: #40