### PR TITLE
Improve modified preference at runtime

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -224,7 +224,7 @@ class HamsterGTK(Gtk.Application):
             dict: Dictionary of config keys and values.
         """
         cp_instance = self._config_to_configparser(config)
-        config_helpers.write_config_file(cp_instance)
+        config_helpers.write_config_file(cp_instance, 'hamster-gtk', 'hamster-gtk.conf')
         self.controler.signal_handler.emit('config-changed')
 
     def _startup(self, app):
@@ -233,7 +233,7 @@ class HamsterGTK(Gtk.Application):
         self._reload_config()
         self.controler = hamster_lib.HamsterControl(self._config)
         self.controler.signal_handler = SignalHandler()
-        self.controler.signal_handler.connect('config-changed', self._reload_config)
+        self.controler.signal_handler.connect('config-changed', self._config_changed)
         # For convenience only
         # [FIXME]
         # Pick one canonical path and stick to it!
@@ -262,11 +262,19 @@ class HamsterGTK(Gtk.Application):
         print('Hamster-GTK shut down.')  # NOQA
 
     # We use sender=None for it to be called as a method as well.
-    def _reload_config(self, sender=None):
+    def _reload_config(self):
         """Reload configuration from designated store."""
         config = self._get_config_from_file()
         self._config = config
         return config
+
+    def _config_changed(self, sender):
+        """Callback triggered when config has been changed."""
+        self._reload_config()
+        # [FIXME]
+        # hamster-lib currentl provides no proper way to update its config
+        # See: https://github.com/projecthamster/hamster-lib/issues/190
+        # We want something like ``self.controler.update_config(self._config)``
 
     def _get_default_config(self):
         """

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -103,8 +103,9 @@ def get_config_instance(fallback_config_instance, app_name, file_name):
     from hamster_lib.helpers import config_helpers
     from backports.configparser import SafeConfigParser
     config = SafeConfigParser()
-    path = config_helpers.get_config_path(app_name)
-    if not config.read(path):
+    path = config_helpers.get_config_path(app_name, file_name)
+    existing_config = config.read(path)
+    if not existing_config:
         config = config_helpers.write_config_file(fallback_config_instance, app_name,
                                                   file_name=file_name)
     return config

--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -82,6 +82,7 @@ class OverviewDialog(Gtk.Dialog):
 
     def _connect_signals(self):
         """Connect signals this instance listens for."""
+        self._app.controler.signal_handler.connect('config-changed', self._on_config_changed)
         self._app.controler.signal_handler.connect('facts-changed', self._on_facts_changed)
         self._app.controler.signal_handler.connect('daterange-changed', self._on_daterange_changed)
 
@@ -89,6 +90,10 @@ class OverviewDialog(Gtk.Dialog):
         """Return the default daterange used when none has been selected by user."""
         today = datetime.date.today()
         return (today, today)
+
+    def _on_config_changed(self, sender):
+        """Callback to be triggered if the applications config has changed."""
+        self.refresh()
 
     def _on_facts_changed(self, sender):
         """Callback to be triggered if stored facts have been changed."""


### PR DESCRIPTION
This PR improves how updated preferences are handled.
It does *not* however successfully fix the issue that updated preferences are not respected before the next restart of the application.
The reason for this is that ``hamster-lib`` does not allow a config update at runtime.
Once [the hamster-lib issue](https://github.com/projecthamster/hamster-lib/issues/190) has been resolved, this should be easy.

What this PR does is:
* fix an error where we would not respect ``appname`` and ``filename`` when retrieving the config, hence fetching the wrong one.
* connect ``OverviewDialog`` to ``config-changed`` signal to trigger a refresh if it is recieved.