### PR TITLE
Move UI to resource files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include .editorconfig
 
 recursive-include tests *
 recursive-include hamster_gtk *.py
+recursive-include hamster_gtk/resources/css *.css
 recursive-include requirements *.pip
 recursive-include docs *.rst conf.py Makefile make.bat
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include .editorconfig
 recursive-include tests *
 recursive-include hamster_gtk *.py
 recursive-include hamster_gtk/resources/css *.css
+recursive-include hamster_gtk/resources/ui *.ui
 recursive-include requirements *.pip
 recursive-include docs *.rst conf.py Makefile make.bat
 

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -38,6 +38,7 @@ import hamster_lib
 from backports.configparser import SafeConfigParser
 from gi.repository import Gdk, GObject, Gtk
 from hamster_lib.helpers import config_helpers
+from hamster_gtk.helpers import get_resource_path
 from six import text_type
 
 # [FIXME]
@@ -117,7 +118,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # Setup css
         style_provider = Gtk.CssProvider()
-        style_provider.load_from_data(self._get_css().encode())
+        style_provider.load_from_path(get_resource_path('css/hamster-gtk.css'))
         Gtk.StyleContext.add_provider_for_screen(
             Gdk.Screen.get_default(),
             style_provider,
@@ -126,55 +127,6 @@ class MainWindow(Gtk.ApplicationWindow):
 
         # Set tracking as default screen at startup.
         self.add(TrackingScreen(self.app))
-
-    def _get_css(self):
-        """
-        Return a string representing our CSS definitions.
-
-        This will be obsolete in the future, once we move it to a dedicated file.
-        See Issue #4.
-        """
-        return """
-            #DayRowDateBox {
-                background: #dfdfdf;
-            }
-
-            #OverviewDateLabel {
-                padding-left: 10px;
-                padding-right: 10px;
-            }
-
-            #OverviewTagLabel {
-                padding: 2px;
-            }
-
-            #OverviewDescriptionLabel {
-                padding-bottom: 20px;
-            }
-
-            #OverviewTagBox {
-                background: gray;
-                border-radius: 5px;
-                border-color: gray;
-                border-width: 1px 1px 1px 1px;
-                border-style: solid;
-                color: white;
-            }
-
-            #OverviewFactList {
-                background: @bg_color;
-            }
-
-            #OverviewFactBox {
-                padding-left: 10px;
-                padding-right: 10px;
-            }
-
-            /* EditDialog */
-            #EditDialogMainBox {
-                padding: 15px;
-            }
-            """
 
 
 # [FIXME]

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -22,7 +22,6 @@
 
 from __future__ import absolute_import, unicode_literals
 
-import collections
 import datetime
 import os.path
 import traceback
@@ -31,6 +30,12 @@ from gettext import gettext as _
 import gi
 gi.require_version('Gdk', '3.0')  # NOQA
 gi.require_version('Gtk', '3.0')  # NOQA
+from hamster_gtk.preferences.widgets import ComboBoxTextConfig # NOQA
+from hamster_gtk.preferences.widgets import EditableFileChooser # NOQA
+from hamster_gtk.preferences.widgets import SpinButtonConfig # NOQA
+from hamster_gtk.preferences.widgets import TimeEntry # NOQA
+from hamster_gtk.preferences.widgets import WidgetConfig # NOQA
+
 import hamster_lib
 # Once we drop py2 support, we can use the builtin again but unicode support
 # under python 2 is practically non existing and manual encoding is not easily
@@ -43,7 +48,7 @@ from six import text_type
 
 # [FIXME]
 # Remove once hamster-lib has been patched
-from hamster_gtk.helpers import _u, get_config_instance
+from hamster_gtk.helpers import get_config_instance
 from hamster_gtk.overview import OverviewDialog
 from hamster_gtk.tracking import TrackingScreen
 
@@ -369,10 +374,13 @@ class HamsterGTK(Gtk.Application):
         return self._configparser_to_config(cp_instance)
 
 
-class PreferencesDialog(Gtk.Dialog):
+class PreferencesDialog(object):
     """A dialog that shows and allows editing of config settings."""
 
-    def __init__(self, parent, app, initial, *args, **kwargs):
+    config_fields = ('store', 'db_engine', 'tmpfile_path', 'db_path',
+                     'day_start', 'fact_min_delta')
+
+    def __init__(self, parent, app, initial):
         """
         Instantiate dialog.
 
@@ -381,200 +389,61 @@ class PreferencesDialog(Gtk.Dialog):
             app (HamsterGTK): Main app instance. Needed in order to retrieve
                 and manipulate config values.
         """
-        super(PreferencesDialog, self).__init__(*args, **kwargs)
-
         self._parent = parent
         self._app = app
 
-        self.set_transient_for(self._parent)
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file(get_resource_path('ui/hamster-gtk-preferences-dialog.ui'))
+        self.builder.connect_signals(self)
 
-        # We use an ordered dict as the order reflects display order as well.
-        self._fields = collections.OrderedDict([
-            ('store', self._get_store_widget(initial=initial['store'])),
-            ('day_start', self._get_day_start_widget(initial=initial['day_start'])),
-            ('fact_min_delta', self._get_fact_min_delta_widget(initial=initial['fact_min_delta'])),
-            ('tmpfile_path', self._get_tmpfile_path_widget(initial=initial['tmpfile_path'])),
-            ('db_engine', self._get_db_engine_widget(initial=initial['db_engine'])),
-            ('db_path', self._get_db_path_widget(initial=initial['db_path'])),
-        ])
+        # Populate stores
+        store_widget = self.builder.get_object('store')
+        for store in hamster_lib.REGISTERED_BACKENDS:
+            store_widget.append(store, hamster_lib.REGISTERED_BACKENDS[store].verbose_name)
 
-        grid = Gtk.Grid()
-        grid.set_hexpand(True)
-        row = 0
-        for key, widgets in self._fields.items():
-            label, widget = widgets
-            grid.attach(label, 0, row, 1, 1)
-            grid.attach(widget, 1, row, 1, 1)
-            row += 1
+        # Populate DB engines
+        db_engine_widget = self.builder.get_object('db_engine')
+        db_engines = ('sqlite', 'postgresql', 'mysql', 'oracle', 'mssql')
+        for engine in db_engines:
+            db_engine_widget.append(engine, engine)
 
-        self.get_content_area().add(grid)
-        self.add_action_widget(self._get_cancel_button(), Gtk.ResponseType.CANCEL)
-        self.add_action_widget(self._get_apply_button(), Gtk.ResponseType.APPLY)
+        # Load config values
+        for key in self.config_fields:
+            widget = self.builder.get_object(key)
+            if not isinstance(widget, WidgetConfig):
+                raise TypeError(_("Unhandled widget class!"))
+            widget.set_config_value(initial[key])
 
-        self.show_all()
+        self.dialog = self.builder.get_object('preferences-dialog')
+        self.dialog.set_transient_for(self._parent)
+
+    def run(self):
+        """Run the dialog."""
+        return self.dialog.run()
+
+    # Signals
+    def destroy(self):
+        """Destroy the dialog."""
+        self.dialog.destroy()
+
+    def on_cancel_clicked(self, widget):
+        """Cancel the changes and close the dialog."""
+        self.dialog.response(Gtk.ResponseType.CANCEL)
+
+    def on_apply_clicked(self, widget):
+        """Apply the changes and close the dialog."""
+        self.dialog.response(Gtk.ResponseType.APPLY)
 
     def get_config(self):
         """Parse config widgets and construct a {field: value} dict."""
-        def get_string(widget):
-            if isinstance(widget, Gtk.Entry):
-                result = _u(widget.get_text())
-            elif isinstance(widget, Gtk.ComboBoxText):
-                index = widget.get_active()
-                result = widget.options[index]
-            elif isinstance(widget, Gtk.Grid):
-                result = _u(widget.entry.get_text())
-            else:
-                raise TypeError(_("Unhandled widget class!"))
-            return result
-
-        def get_time(widget):
-            if isinstance(widget, Gtk.Entry):
-                result = _u(widget.get_text())
-                # We are tollerant against malformed time information.
-                try:
-                    result = datetime.datetime.strptime(result, '%H:%M:%S').time()
-                except ValueError:
-                    result = datetime.datetime.strptime(result, '%H:%M').time()
-            else:
-                raise TypeError(_("Unhandled widget class!"))
-            return result
-
-        def get_int(widget):
-            string = get_string(widget)
-            result = None
-            if string:
-                result = int(string)
-            return result
-
-        string_fields = ('store', 'tmpfile_path', 'db_engine', 'db_path')
-        time_fields = ('day_start',)
-        int_fields = ('fact_min_delta',)
-
         result = {}
-        for key in string_fields:
-            label, widget = self._fields[key]
-            result[key] = get_string(widget)
+        for key in self.config_fields:
+            widget = self.builder.get_object(key)
+            if not isinstance(widget, WidgetConfig):
+                raise TypeError(_("Unhandled widget class!"))
+            result[key] = widget.get_config_value()
 
-        for key in time_fields:
-            label, widget = self._fields[key]
-            result[key] = get_time(widget)
-
-        for key in int_fields:
-            label, widget = self._fields[key]
-            result[key] = get_int(widget)
         return result
-
-    # Widgets
-    def _get_apply_button(self):
-        """Return a *apply* button."""
-        return Gtk.Button.new_from_stock(Gtk.STOCK_APPLY)
-
-    def _get_cancel_button(self):
-        """Return a *cancel* button."""
-        return Gtk.Button.new_from_stock(Gtk.STOCK_CANCEL)
-
-    def _get_store_widget(self, initial=None):
-        """Return widget to set the backend store."""
-        label = Gtk.Label(_("Store"))
-        widget = Gtk.ComboBoxText()
-        # It seems Gtk.ComboBox provides no easy access to its stored options
-        # that would allow getting their index. The index however is needed in
-        # order to programmatically set an option. Until we find a better
-        # solution we need to keep our own 'string-to-index' mapping.
-        # We create a immutable duplicate of the original store list in order
-        # to prevent accidental side effects and changes to the list effecting
-        # the combobox index.
-        widget.options = tuple(hamster_lib.REGISTERED_BACKENDS.keys())
-        for store in hamster_lib.REGISTERED_BACKENDS.values():
-            widget.append_text(store.verbose_name)
-        if initial:
-            widget.set_active(widget.options.index(initial))
-        return (label, widget)
-
-    def _get_day_start_widget(self, initial=None):
-        """Return widget to set the *day start* value."""
-        label_text = "{} (HH:MM:SS)".format(_("Day Start"))
-        label = Gtk.Label(label_text)
-        widget = Gtk.Entry()
-        # We need to be explicit about 'None'. A bool(datetime.time(0, 0, 0))
-        # evaluates to False and as a consequence would not trigger the setting
-        # of the initial value.
-        if initial is not None:
-            widget.set_text(text_type(initial.strftime('%H:%M:%S')))
-        return (label, widget)
-
-    def _get_fact_min_delta_widget(self, initial=None):
-        """Return widget to set the minimum duration for a fact."""
-        label = Gtk.Label(_("Minimal Fact Duration"))
-        widget = Gtk.Entry()
-        # We need to check for None in order to allow 0 as initial value.
-        if initial is not None:
-            widget.set_text(text_type(int(initial)))
-        return (label, widget)
-
-    def _get_tmpfile_path_widget(self, initial=None):
-        """Return widget to set the location to save the tmp fact."""
-        label = Gtk.Label(_("Full 'tmpfile'-path"))
-        grid = self._get_path_entry_with_button(initial,
-            self._on_tmpfile_path_choose_button_clicked)
-        return (label, grid)
-
-    def _get_db_engine_widget(self, initial=None):
-        """Return widget to specify the *db-engine* value."""
-        label = Gtk.Label(_("DB Engine"))
-        widget = Gtk.ComboBoxText()
-        widget.options = ('sqlite', 'postgresql', 'mysql', 'oracle', 'mssql')
-        for engine in widget.options:
-            widget.append_text(engine)
-        if initial:
-            widget.set_active(widget.options.index(initial))
-        return (label, widget)
-
-    def _get_db_path_widget(self, initial=None):
-        """Return a widget to specify the *db-path*."""
-        label = Gtk.Label(_("DB Path"))
-        grid = self._get_path_entry_with_button(initial,
-            self._on_db_path_choose_button_clicked)
-        return (label, grid)
-
-    # Callbacks
-    def _on_tmpfile_path_choose_button_clicked(self, button):
-        """Open a dialog to select path."""
-        self._update_entry_via_filechooser('tmpfile_path')
-
-    def _on_db_path_choose_button_clicked(self, button):
-        """Open a dialog to select path."""
-        self._update_entry_via_filechooser('db_path')
-
-    # Helpers
-    def _update_entry_via_filechooser(self, fieldname):
-        """Open a dialog to select path and update entry widget with it."""
-        def update_entry(new_path):
-            entry = self._fields[fieldname][1].entry
-            entry.set_text(text_type(new_path))
-        dialog = Gtk.FileChooserDialog(_("Please choose a directory"), self,
-            Gtk.FileChooserAction.SAVE, (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                         Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
-        response = dialog.run()
-        if response == Gtk.ResponseType.OK:
-            update_entry(dialog.get_filename())
-        else:
-            pass
-        dialog.destroy()
-
-    def _get_path_entry_with_button(self, initial, callback):
-        """Return a path entry field with accompanying button."""
-        entry = Gtk.Entry()
-        entry.set_hexpand(True)
-        button = Gtk.Button(_("Choose"))
-        button.connect('clicked', callback)
-        grid = Gtk.Grid()
-        grid.entry = entry
-        grid.attach(entry, 0, 0, 1, 1)
-        grid.attach(button, 1, 0, 1, 1)
-        if initial:
-            entry.set_text(text_type(initial))
-        return grid
 
 
 def _main():

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -22,6 +22,7 @@
 import datetime
 
 import six
+import os.path
 
 from . import dialogs
 
@@ -109,3 +110,8 @@ def get_config_instance(fallback_config_instance, app_name, file_name):
         config = config_helpers.write_config_file(fallback_config_instance, app_name,
                                                   file_name=file_name)
     return config
+
+
+def get_resource_path(file_name):
+    """Return path to a resource file."""
+    return os.path.join(os.path.dirname(__file__), 'resources', file_name)

--- a/hamster_gtk/preferences/__init__.py
+++ b/hamster_gtk/preferences/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides various widgets for preferences dialog."""

--- a/hamster_gtk/preferences/widgets/__init__.py
+++ b/hamster_gtk/preferences/widgets/__init__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides widgets to be used by the preferences dialog."""
+
+from .combo_box_text_config import ComboBoxTextConfig # NOQA
+from .editable_file_chooser import EditableFileChooser # NOQA
+from .spin_button_config import SpinButtonConfig # NOQA
+from .time_entry import TimeEntry # NOQA
+from .widget_config import WidgetConfig # NOQA

--- a/hamster_gtk/preferences/widgets/combo_box_text_config.py
+++ b/hamster_gtk/preferences/widgets/combo_box_text_config.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides ComboBoxText widget extended to store preferences."""
+
+from __future__ import absolute_import
+
+from gi.repository import Gtk
+from .widget_config import WidgetConfig
+
+
+class ComboBoxTextConfig(Gtk.ComboBoxText, WidgetConfig):
+    """A combo box that stores configuration."""
+
+    # Required else you would need to specify the full module
+    # name in ui file
+    __gtype_name__ = 'ComboBoxTextConfig'
+
+    def get_config_value(self):
+        """Return selected value."""
+        return self.get_active_id()
+
+    def set_config_value(self, value):
+        """Select given value."""
+        self.set_active_id(value)

--- a/hamster_gtk/preferences/widgets/editable_file_chooser.py
+++ b/hamster_gtk/preferences/widgets/editable_file_chooser.py
@@ -72,3 +72,8 @@ class EditableFileChooser(Gtk.Grid, WidgetConfig):
             self.entry.set_text(text_type(dialog.get_filename()))
 
         dialog.destroy()
+
+    @GtkTemplate.Callback
+    def on_mnemonic_activate(self, widget, arg1, template):
+        """Mnemonic associated with this widget was activated."""
+        return self.entry.do_mnemonic_activate(self.entry, False)

--- a/hamster_gtk/preferences/widgets/editable_file_chooser.py
+++ b/hamster_gtk/preferences/widgets/editable_file_chooser.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides file chooser widget."""
+
+# [FIXME]
+# Adding 'unicode_literals' raises encoding issues. This is a major sign we
+# have a unicode issue!
+from __future__ import absolute_import
+
+from gi.repository import Gtk
+from gi_composites import GtkTemplate
+from gettext import gettext as _
+
+from six import text_type
+
+from hamster_gtk.helpers import get_resource_path
+from .widget_config import WidgetConfig
+
+
+@GtkTemplate(ui=get_resource_path('ui/editable-file-chooser.ui'))
+class EditableFileChooser(Gtk.Grid, WidgetConfig):
+    """A file chooser that also has an entry for changing the path."""
+
+    # Required else you would need to specify the full module
+    # name in ui file
+    __gtype_name__ = 'EditableFileChooser'
+
+    entry = GtkTemplate.Child()
+
+    def __init__(self):
+        """Initialize widget."""
+        super(Gtk.Grid, self).__init__()
+        self.init_template()
+
+    def get_config_value(self):
+        """Return value of the entry."""
+        return self.entry.get_text()
+
+    def set_config_value(self, value):
+        """Set value of the entry."""
+        self.entry.set_text(text_type(value))
+
+    @GtkTemplate.Callback
+    def on_choose_clicked(self, widget, template):
+        """Open a dialog to select path and update entry widget with it."""
+        # Reliably determine parent window
+        # https://developer.gnome.org/gtk3/unstable/GtkWidget.html#gtk-widget-get-toplevel
+        toplevel = self.get_toplevel()
+        if not toplevel.is_toplevel():
+            toplevel = None
+
+        dialog = Gtk.FileChooserDialog(_("Please choose a directory"), toplevel,
+            Gtk.FileChooserAction.SAVE, (_("_Cancel"), Gtk.ResponseType.CANCEL,
+                                         _("_Save"), Gtk.ResponseType.OK))
+        response = dialog.run()
+        if response == Gtk.ResponseType.OK:
+            self.entry.set_text(text_type(dialog.get_filename()))
+
+        dialog.destroy()

--- a/hamster_gtk/preferences/widgets/spin_button_config.py
+++ b/hamster_gtk/preferences/widgets/spin_button_config.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides SpinButton widget extended to store preferences."""
+
+from __future__ import absolute_import
+
+from gi.repository import Gtk
+from .widget_config import WidgetConfig
+
+
+class SpinButtonConfig(Gtk.SpinButton, WidgetConfig):
+    """A spin button that stores configuration."""
+
+    # Required else you would need to specify the full module
+    # name in ui file
+    __gtype_name__ = 'SpinButtonConfig'
+
+    def get_config_value(self):
+        """Return selected value."""
+        return self.get_value_as_int()
+
+    def set_config_value(self, value):
+        """Set given value."""
+        # We need to check for None in order to allow 0 as initial value.
+        if value is not None:
+            self.set_value(int(value))

--- a/hamster_gtk/preferences/widgets/time_entry.py
+++ b/hamster_gtk/preferences/widgets/time_entry.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides a widget for entering time."""
+
+from __future__ import absolute_import
+
+from gi.repository import Gtk
+from .widget_config import WidgetConfig
+import datetime
+
+# [FIXME]
+# Remove once hamster-lib has been patched
+from hamster_gtk.helpers import _u
+from six import text_type
+
+
+class TimeEntry(Gtk.Entry, WidgetConfig):
+    """A widget for entering time."""
+
+    # Required else you would need to specify the full module
+    # name in ui file
+    __gtype_name__ = 'TimeEntry'
+
+    def get_config_value(self):
+        """Return selected value."""
+        result = _u(self.get_text())
+        # We are tollerant against malformed time information.
+        try:
+            result = datetime.datetime.strptime(result, '%H:%M:%S').time()
+        except ValueError:
+            result = datetime.datetime.strptime(result, '%H:%M').time()
+
+        return result
+
+    def set_config_value(self, value):
+        """Select given value."""
+        # We need to be explicit about 'None'. A bool(datetime.time(0, 0, 0))
+        # evaluates to False and as a consequence would not trigger the setting
+        # of the initial value.
+        if value is not None:
+            self.set_text(text_type(value.strftime('%H:%M:%S')))

--- a/hamster_gtk/preferences/widgets/widget_config.py
+++ b/hamster_gtk/preferences/widgets/widget_config.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides “interface” for config widgets."""
+
+
+class WidgetConfig:
+    """Abstract class representing widgets for changing preferences."""
+
+    def get_config_value(self):
+        """Get widget value."""
+        raise NotImplemented
+
+    def set_config_value(self, value):
+        """Set widget value."""
+        raise NotImplemented

--- a/hamster_gtk/resources/css/hamster-gtk.css
+++ b/hamster_gtk/resources/css/hamster-gtk.css
@@ -1,0 +1,39 @@
+#DayRowDateBox {
+	background: #dfdfdf;
+}
+
+#OverviewDateLabel {
+	padding-left: 10px;
+	padding-right: 10px;
+}
+
+#OverviewTagLabel {
+	padding: 2px;
+}
+
+#OverviewDescriptionLabel {
+	padding-bottom: 20px;
+}
+
+#OverviewTagBox {
+	background: gray;
+	border-radius: 5px;
+	border-color: gray;
+	border-width: 1px 1px 1px 1px;
+	border-style: solid;
+	color: white;
+}
+
+#OverviewFactList {
+	background: @bg_color;
+}
+
+#OverviewFactBox {
+	padding-left: 10px;
+	padding-right: 10px;
+}
+
+/* EditDialog */
+#EditDialogMainBox {
+	padding: 15px;
+}

--- a/hamster_gtk/resources/ui/editable-file-chooser.ui
+++ b/hamster_gtk/resources/ui/editable-file-chooser.ui
@@ -3,6 +3,7 @@
 	<template class="EditableFileChooser" parent="GtkGrid">
 		<property name="visible">True</property>
 		<property name="can_focus">False</property>
+		<signal name="mnemonic-activate" handler="on_mnemonic_activate" object="EditableFileChooser" swapped="no"/>
 		<child>
 			<object class="GtkEntry" id="entry">
 				<property name="visible">True</property>

--- a/hamster_gtk/resources/ui/editable-file-chooser.ui
+++ b/hamster_gtk/resources/ui/editable-file-chooser.ui
@@ -1,0 +1,30 @@
+<interface>
+	<requires lib="gtk+" version="3.20"/>
+	<template class="EditableFileChooser" parent="GtkGrid">
+		<property name="visible">True</property>
+		<property name="can_focus">False</property>
+		<child>
+			<object class="GtkEntry" id="entry">
+				<property name="visible">True</property>
+				<property name="can_focus">True</property>
+			</object>
+			<packing>
+				<property name="left_attach">0</property>
+				<property name="top_attach">0</property>
+			</packing>
+		</child>
+		<child>
+			<object class="GtkButton" id="button">
+				<property name="label" translatable="yes">Choose</property>
+				<property name="visible">True</property>
+				<property name="can_focus">True</property>
+				<property name="receives_default">True</property>
+				<signal name="clicked" handler="on_choose_clicked" object="EditableFileChooser" swapped="no"/>
+			</object>
+			<packing>
+				<property name="left_attach">1</property>
+				<property name="top_attach">0</property>
+			</packing>
+		</child>
+	</template>
+</interface>

--- a/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
+++ b/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
@@ -80,7 +80,7 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">_Day Start (HH:MM:SS)</property>
+										<property name="label" translatable="yes" comments="Do not change the time format, the application currently expects input in the form HH:MM:SS.">_Day Start (HH:MM:SS)</property>
 										<property name="use_underline">True</property>
 										<property name="mnemonic_widget">day_start</property>
 									</object>

--- a/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
+++ b/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
@@ -19,6 +19,7 @@
 	<object class="GtkDialog" id="preferences-dialog">
 		<property name="can_focus">False</property>
 		<property name="type_hint">dialog</property>
+		<property name="title" translatable="yes">Preferences</property>
 		<child internal-child="vbox">
 			<object class="GtkBox">
 				<property name="can_focus">False</property>

--- a/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
+++ b/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
@@ -1,0 +1,244 @@
+<interface>
+	<requires lib="gtk+" version="3.20"/>
+	<object class="GtkImage" id="icon-apply">
+		<property name="visible">True</property>
+		<property name="can_focus">False</property>
+		<property name="icon_name">dialog-ok</property>
+	</object>
+	<object class="GtkImage" id="icon-cancel">
+		<property name="visible">True</property>
+		<property name="can_focus">False</property>
+		<property name="icon_name">dialog-cancel</property>
+	</object>
+	<object class="GtkAdjustment" id="delta-adjustment">
+		<property name="lower">0</property>
+		<property name="upper">999999</property>
+		<property name="step_increment">1</property>
+		<property name="page_increment">10</property>
+	</object>
+	<object class="GtkDialog" id="preferences-dialog">
+		<property name="can_focus">False</property>
+		<property name="type_hint">dialog</property>
+		<child internal-child="vbox">
+			<object class="GtkBox">
+				<property name="can_focus">False</property>
+				<property name="orientation">vertical</property>
+				<property name="spacing">2</property>
+				<child internal-child="action_area">
+					<object class="GtkButtonBox">
+						<property name="can_focus">False</property>
+						<property name="layout_style">end</property>
+						<child>
+							<object class="GtkButton" id="preferences-cancel">
+								<property name="label" translatable="yes">_Cancel</property>
+								<property name="visible">True</property>
+								<property name="can_focus">True</property>
+								<property name="receives_default">True</property>
+								<property name="use_underline">True</property>
+								<property name="image">icon-cancel</property>
+								<signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
+							</object>
+							<packing>
+								<property name="expand">True</property>
+								<property name="fill">True</property>
+								<property name="position">0</property>
+							</packing>
+						</child>
+						<child>
+							<object class="GtkButton" id="preferences-apply">
+								<property name="label" translatable="yes">_Apply</property>
+								<property name="visible">True</property>
+								<property name="can_focus">True</property>
+								<property name="receives_default">True</property>
+								<property name="use_underline">True</property>
+								<property name="image">icon-apply</property>
+								<signal name="clicked" handler="on_apply_clicked" swapped="no"/>
+							</object>
+							<packing>
+								<property name="expand">True</property>
+								<property name="fill">True</property>
+								<property name="position">1</property>
+							</packing>
+						</child>
+					</object>
+					<packing>
+						<property name="expand">False</property>
+						<property name="fill">False</property>
+						<property name="position">0</property>
+					</packing>
+				</child>
+				<child>
+					<object class="GtkNotebook">
+						<property name="visible">True</property>
+						<property name="can_focus">True</property>
+						<child>
+							<object class="GtkGrid">
+								<property name="visible">True</property>
+								<property name="can_focus">False</property>
+								<child>
+									<object class="GtkLabel">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+										<property name="label" translatable="yes">Day Start (HH:MM:SS)</property>
+									</object>
+									<packing>
+										<property name="left_attach">0</property>
+										<property name="top_attach">0</property>
+									</packing>
+								</child>
+								<child>
+									<object class="TimeEntry" id="day_start">
+										<property name="visible">True</property>
+										<property name="can_focus">True</property>
+									</object>
+									<packing>
+										<property name="left_attach">1</property>
+										<property name="top_attach">0</property>
+									</packing>
+								</child>
+								<child>
+									<object class="GtkLabel">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+										<property name="label" translatable="yes">Minimal Fact Duration</property>
+									</object>
+									<packing>
+										<property name="left_attach">0</property>
+										<property name="top_attach">1</property>
+									</packing>
+								</child>
+								<child>
+									<object class="SpinButtonConfig" id="fact_min_delta">
+										<property name="visible">True</property>
+										<property name="can_focus">True</property>
+										<property name="adjustment">delta-adjustment</property>
+									</object>
+									<packing>
+										<property name="left_attach">1</property>
+										<property name="top_attach">1</property>
+									</packing>
+								</child>
+							</object>
+						</child>
+						<child type="tab">
+							<object class="GtkLabel">
+								<property name="visible">True</property>
+								<property name="can_focus">False</property>
+								<property name="label" translatable="yes">Tracking</property>
+							</object>
+							<packing>
+								<property name="tab_fill">False</property>
+							</packing>
+						</child>
+						<child>
+							<object class="GtkGrid">
+								<property name="visible">True</property>
+								<property name="can_focus">False</property>
+								<child>
+									<object class="GtkLabel">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+										<property name="label" translatable="yes">Store</property>
+									</object>
+									<packing>
+										<property name="left_attach">0</property>
+										<property name="top_attach">0</property>
+									</packing>
+								</child>
+								<child>
+									<object class="ComboBoxTextConfig" id="store">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+									</object>
+									<packing>
+										<property name="left_attach">1</property>
+										<property name="top_attach">0</property>
+									</packing>
+								</child>
+								<child>
+									<object class="GtkLabel">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+										<property name="label" translatable="yes">DB Engine</property>
+									</object>
+									<packing>
+										<property name="left_attach">0</property>
+										<property name="top_attach">1</property>
+									</packing>
+								</child>
+								<child>
+									<object class="ComboBoxTextConfig" id="db_engine">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+									</object>
+									<packing>
+										<property name="left_attach">1</property>
+										<property name="top_attach">1</property>
+									</packing>
+								</child>
+								<child>
+									<object class="GtkLabel">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+										<property name="label" translatable="yes">DB Path</property>
+									</object>
+									<packing>
+										<property name="left_attach">0</property>
+										<property name="top_attach">2</property>
+									</packing>
+								</child>
+								<child>
+									<object class="EditableFileChooser" id="db_path">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+									</object>
+									<packing>
+										<property name="left_attach">1</property>
+										<property name="top_attach">2</property>
+									</packing>
+								</child>
+								<child>
+									<object class="GtkLabel">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+										<property name="label" translatable="yes">Temporary file</property>
+									</object>
+									<packing>
+										<property name="left_attach">0</property>
+										<property name="top_attach">3</property>
+									</packing>
+								</child>
+								<child>
+									<object class="EditableFileChooser" id="tmpfile_path">
+										<property name="visible">True</property>
+										<property name="can_focus">False</property>
+									</object>
+									<packing>
+										<property name="left_attach">1</property>
+										<property name="top_attach">3</property>
+									</packing>
+								</child>
+							</object>
+						</child>
+						<child type="tab">
+							<object class="GtkLabel">
+								<property name="visible">True</property>
+								<property name="can_focus">False</property>
+								<property name="label" translatable="yes">Storage</property>
+							</object>
+							<packing>
+								<property name="position">1</property>
+								<property name="tab_fill">False</property>
+							</packing>
+						</child>
+					</object>
+					<packing>
+						<property name="expand">True</property>
+						<property name="fill">True</property>
+						<property name="position">1</property>
+					</packing>
+				</child>
+			</object>
+		</child>
+	</object>
+</interface>

--- a/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
+++ b/hamster_gtk/resources/ui/hamster-gtk-preferences-dialog.ui
@@ -79,7 +79,9 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">Day Start (HH:MM:SS)</property>
+										<property name="label" translatable="yes">_Day Start (HH:MM:SS)</property>
+										<property name="use_underline">True</property>
+										<property name="mnemonic_widget">day_start</property>
 									</object>
 									<packing>
 										<property name="left_attach">0</property>
@@ -100,7 +102,9 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">Minimal Fact Duration</property>
+										<property name="label" translatable="yes">_Minimal Fact Duration</property>
+										<property name="use_underline">True</property>
+										<property name="mnemonic_widget">fact_min_delta</property>
 									</object>
 									<packing>
 										<property name="left_attach">0</property>
@@ -138,7 +142,9 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">Store</property>
+										<property name="label" translatable="yes">_Store</property>
+										<property name="use_underline">True</property>
+										<property name="mnemonic_widget">store</property>
 									</object>
 									<packing>
 										<property name="left_attach">0</property>
@@ -159,7 +165,9 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">DB Engine</property>
+										<property name="label" translatable="yes">DB _Engine</property>
+										<property name="use_underline">True</property>
+										<property name="mnemonic_widget">db_engine</property>
 									</object>
 									<packing>
 										<property name="left_attach">0</property>
@@ -180,7 +188,9 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">DB Path</property>
+										<property name="label" translatable="yes">DB _Path</property>
+										<property name="use_underline">True</property>
+										<property name="mnemonic_widget">db_path</property>
 									</object>
 									<packing>
 										<property name="left_attach">0</property>
@@ -201,7 +211,9 @@
 									<object class="GtkLabel">
 										<property name="visible">True</property>
 										<property name="can_focus">False</property>
-										<property name="label" translatable="yes">Temporary file</property>
+										<property name="label" translatable="yes">_Temporary file</property>
+										<property name="use_underline">True</property>
+										<property name="mnemonic_widget">tmpfile_path</property>
 									</object>
 									<packing>
 										<property name="left_attach">0</property>

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'hamster-lib',
+    'pygi-composite-templates'
 ]
 
 setup(
@@ -47,6 +48,7 @@ setup(
     hamster-gtk=hamster_gtk.hamster_gtk:_main
     ''',
     package_data={'hamster_gtk': [
-        'resources/css/*.css'
+        'resources/css/*.css',
+        'resources/ui/*.ui'
     ]}
 )

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,8 @@ setup(
     entry_points='''
     [gui_scripts]
     hamster-gtk=hamster_gtk.hamster_gtk:_main
-    '''
+    ''',
+    package_data={'hamster_gtk': [
+        'resources/css/*.css'
+    ]}
 )

--- a/tests/preferences/__init__.py
+++ b/tests/preferences/__init__.py
@@ -1,0 +1,1 @@
+"""Unittests for the preferences submodule."""

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+"""Fixtures for unittesting the preferences submodule."""
+
+from __future__ import absolute_import, unicode_literals
+
+import datetime
+from gi.repository import Gtk
+import os.path
+import pytest
+
+from hamster_gtk.preferences import widgets
+
+
+# Instances
+
+@pytest.fixture
+def combo_box_text_config(request, combo_box_items):
+    """Return a ComboBoxTextConfig instance."""
+    widget = widgets.ComboBoxTextConfig()
+    for id, item in combo_box_items:
+        widget.append(id, item)
+    return widget
+
+
+@pytest.fixture
+def editable_file_chooser(request):
+    """Return a EditableFileChooser instance."""
+    return widgets.EditableFileChooser()
+
+
+@pytest.fixture
+def spin_button_config(request, adjustment):
+    """Return a SpinButtonConfig instance."""
+    return widgets.SpinButtonConfig(adjustment)
+
+
+@pytest.fixture
+def time_entry(request):
+    """Return a TimeEntry instance."""
+    return widgets.TimeEntry()
+
+
+# Data
+
+@pytest.fixture
+def combo_box_items(request, faker):
+    """Return a collection of items to be placed into ComboBox."""
+    amount = 5
+    return [(faker.user_name(), faker.name()) for i in range(amount)]
+
+
+@pytest.fixture
+def paths(request, faker):
+    """Return a list of file paths."""
+    amount = 3
+    return [os.path.join(faker.uri(), faker.uri_path()) for i in range(amount)]
+
+
+@pytest.fixture
+def adjustment(request, faker, numbers):
+    """Return a list of random numbers."""
+    value = sorted(numbers)[len(numbers) // 2]
+    lower = min(numbers)
+    upper = max(numbers)
+    step_increment = 1
+    page_increment = 5
+    page_size = 5
+    return Gtk.Adjustment(value, lower, upper, step_increment, page_increment, page_size)
+
+
+@pytest.fixture
+def numbers(request, faker):
+    """Return a list of random numbers."""
+    amount = 8
+    return [faker.random_number(digits=5) for i in range(amount)]
+
+
+@pytest.fixture
+def times(request, faker):
+    """Return a list of random numbers."""
+    amount = 3
+    return [datetime.datetime.strptime(faker.time(), '%H:%M:%S').time() for i in range(amount)]

--- a/tests/preferences/test_widgets.py
+++ b/tests/preferences/test_widgets.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, unicode_literals
+
+from gi.repository import Gtk
+import random
+
+from hamster_gtk.preferences import widgets
+
+
+class TestComboBoxTextConfig(object):
+    """Unittests for ComboBoxTextConfig."""
+
+    def test_init(self):
+        """Make sure minimal initialisation works."""
+        combo_box = widgets.ComboBoxTextConfig()
+        assert combo_box
+
+    def test_instance(self):
+        """Make sure the widget is still a ComboBoxText."""
+        combo_box = widgets.ComboBoxTextConfig()
+        assert isinstance(combo_box, Gtk.ComboBoxText)
+
+    def test_set_get(self, combo_box_text_config, combo_box_items):
+        """Make sure the widget returns the same value it received."""
+        random_id = random.choice(combo_box_items)[0]
+        combo_box_text_config.set_config_value(random_id)
+        assert combo_box_text_config.get_config_value() == random_id
+
+        another_random_id = random.choice(combo_box_items)[0]
+        combo_box_text_config.set_config_value(another_random_id)
+        assert combo_box_text_config.get_config_value() == another_random_id
+
+
+class TestEditableFileChooser(object):
+    """Unittests for EditableFileChooser."""
+
+    def test_init(self):
+        """Make sure minimal initialisation works."""
+        file_chooser = widgets.EditableFileChooser()
+        assert file_chooser
+
+    def test_instance(self):
+        """Make sure the widget is still a Grid."""
+        file_chooser = widgets.EditableFileChooser()
+        assert isinstance(file_chooser, Gtk.Grid)
+
+    def test_set_get(self, editable_file_chooser, paths):
+        """Make sure the widget returns the same value it received."""
+        for path in paths:
+            editable_file_chooser.set_config_value(path)
+            assert editable_file_chooser.get_config_value() == path
+
+
+class TestSpinButtonConfig(object):
+    """Unittests for SpinButtonConfig."""
+
+    def test_init(self):
+        """Make sure minimal initialisation works."""
+        spinner = widgets.SpinButtonConfig()
+        assert spinner
+
+    def test_instance(self):
+        """Make sure the widget is still a SpinButton."""
+        spinner = widgets.SpinButtonConfig()
+        assert isinstance(spinner, Gtk.SpinButton)
+
+    def test_set_get(self, spin_button_config, numbers):
+        """Make sure the widget returns the same value it received."""
+        for number in numbers:
+            spin_button_config.set_config_value(number)
+            assert spin_button_config.get_config_value() == number
+
+
+class TestTimeEntry(object):
+    """Unittests for TimeEntry."""
+
+    def test_init(self):
+        """Make sure minimal initialisation works."""
+        entry = widgets.TimeEntry()
+        assert entry
+
+    def test_instance(self):
+        """Make sure the widget is still a Entry."""
+        entry = widgets.TimeEntry()
+        assert isinstance(entry, Gtk.Entry)
+
+    def test_set_get(self, time_entry, times):
+        """Make sure the widget returns the same value it received."""
+        for time in times:
+            time_entry.set_config_value(time)
+            assert time_entry.get_config_value() == time

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -6,7 +6,6 @@ import datetime
 import os.path
 
 from gi.repository import Gtk
-from six import text_type
 
 import hamster_gtk.hamster_gtk as hamster_gtk
 from hamster_gtk.tracking import TrackingScreen

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -71,10 +71,6 @@ class TestMainWindow(object):
         assert isinstance(window.app, hamster_gtk.HamsterGTK)
         assert isinstance(window.get_children()[0], TrackingScreen)
 
-    def test_get_css(self, main_window):
-        """Make sure a string is returned."""
-        assert isinstance(main_window._get_css(), text_type)
-
 
 class TestHeaderBar(object):
     """Unittests for main window titlebar."""

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -122,9 +122,10 @@ class TestPreferencesDialog(object):
     def test_init(self, dummy_window, app, config):
         """Make instantiation works as expected."""
         result = hamster_gtk.PreferencesDialog(dummy_window, app, config)
-        grid = result.get_content_area().get_children()[0]
+        grids = result.dialog.get_content_area().get_children()[0].get_children()
         # This assumes 2 children per config entry (label and widget).
-        assert len(grid.get_children()) / 2 == len(config.keys())
+        grid_entry_counts = map(lambda g: len(g.get_children()) / 2, grids)
+        assert sum(grid_entry_counts) == len(config.keys())
 
     def test_get_config(self, dummy_window, app, initial_config_parametrized):
         """
@@ -136,39 +137,3 @@ class TestPreferencesDialog(object):
         dialog = hamster_gtk.PreferencesDialog(dummy_window, app, initial_config_parametrized)
         result = dialog.get_config()
         assert result == initial_config_parametrized
-
-    def test_get_store_widget(self, preferences_dialog):
-        """Make sure widgets match expectation."""
-        label, widget = preferences_dialog._get_store_widget()
-        assert isinstance(label, Gtk.Label)
-        assert isinstance(widget, Gtk.ComboBoxText)
-
-    def test_get_day_start_widget(self, preferences_dialog):
-        """Make sure widgets match expectation."""
-        label, widget = preferences_dialog._get_day_start_widget()
-        assert isinstance(label, Gtk.Label)
-        assert isinstance(widget, Gtk.Entry)
-
-    def test_get_fact_min_delta_widget(self, preferences_dialog):
-        """Make sure widgets match expectation."""
-        label, widget = preferences_dialog._get_fact_min_delta_widget()
-        assert isinstance(label, Gtk.Label)
-        assert isinstance(widget, Gtk.Entry)
-
-    def test_get_tmpfile_path_widget(self, preferences_dialog):
-        """Make sure widgets match expectation."""
-        label, widget = preferences_dialog._get_tmpfile_path_widget()
-        assert isinstance(label, Gtk.Label)
-        assert isinstance(widget, Gtk.Grid)
-
-    def test_get_db_engine_widget(self, preferences_dialog):
-        """Make sure widgets match expectation."""
-        label, widget = preferences_dialog._get_db_engine_widget()
-        assert isinstance(label, Gtk.Label)
-        assert isinstance(widget, Gtk.ComboBoxText)
-
-    def test_get_db_path_widget(self, preferences_dialog):
-        """Make sure widgets match expectation."""
-        label, widget = preferences_dialog._get_db_path_widget()
-        assert isinstance(label, Gtk.Label)
-        assert isinstance(widget, Gtk.Grid)


### PR DESCRIPTION
After resolving #4, I have decided to port the UI to Gtk.Builder/Glade. Doubtlessly, this separation will lead to cleaner and more maintainable code, basically [i18n](https://github.com/projecthamster/hamster-gtk/issues/42) for free!

Currently only the Preferences dialog is ported, which I also polished slightly; other parts of the application can follow later.

In the future, other than porting more modules, we should look into handling the files as [glib resources](https://developer.gnome.org/gio/2.32/gio-GResource.html), if it is even possible without the autotools mess.