### PR TITLE
[#74] Fix broken raw fact format in 'EditDialog'

### DIFF
--- a/hamster_gtk/misc/dialogs.py
+++ b/hamster_gtk/misc/dialogs.py
@@ -311,9 +311,9 @@ class EditFactDialog(Gtk.Dialog):
         # [FIXME]
         # Maybe it would be sensible to have a serialization helper method as
         # part of ``hamster-lib``?!
-        label = '{start}-{end} {activity}@{category}'.format(
-            start=self._fact.start.strftime('%H:%M'),
-            end=self._fact.end.strftime("%H:%M"),
+        label = '{start} - {end} {activity}@{category}'.format(
+            start=self._fact.start.strftime('%Y-%m-%d %H:%M'),
+            end=self._fact.end.strftime("%Y-%m-%d %H:%M"),
             activity=text_type(self._fact.activity.name),
             category=text_type(self._fact.category.name)
         )

--- a/tests/misc/test_dialogs.py
+++ b/tests/misc/test_dialogs.py
@@ -181,17 +181,19 @@ class TestEditFactDialog(object):
     # Add tests for changed values.
     def test_updated_fact_same(self, dummy_window, fact):
         """
-        Make sure the property returns Fact matching field values.
+        Make sure the property returns Fact with matching field values.
 
         We need to jump through some extra hoops because we the current
         implementation will always set the edited fact to today as well as ignore
         all 'second' time info.
         """
         dialog = dialogs.EditFactDialog(dummy_window, fact)
-        today = datetime.date.today()
-        fact.start = datetime.datetime.combine(today, fact.start.time()).replace(second=0)
-        fact.end = datetime.datetime.combine(today, fact.end.time()).replace(second=0)
         result = dialog.updated_fact
+        # The default 'raw fact' used in populating the entry field does discard
+        # the original facts timeinfos seconds. This would couse a mismatch, so
+        # we account for it manually.
+        fact.start = fact.start.replace(second=0)
+        fact.end = fact.end.replace(second=0)
         assert result.as_tuple() == fact.as_tuple()
 
 


### PR DESCRIPTION
The release of ``hamster-lib 0.12.0`` introduced some minor changes to the timeinfo format used in a *raw fact* which in turn broke the ``EditDialog``.
This is fixed by this PR.

We also refined the corresponding test as to ignore mismatching 'seconds' values down to our liberal parsing.

Fixes #74