### PR TITLE
[#17] Add  about dialog

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -43,6 +43,7 @@ from six import text_type
 # [FIXME]
 # Remove once hamster-lib has been patched
 from hamster_gtk.helpers import _u, get_config_instance
+from hamster_gtk.misc import HamsterAboutDialog as AboutDialog
 from hamster_gtk.overview import OverviewDialog
 from hamster_gtk.tracking import TrackingScreen
 
@@ -66,6 +67,7 @@ class HeaderBar(Gtk.HeaderBar):
 
         self.pack_end(self._get_preferences_button())
         self.pack_end(self._get_overview_button())
+        self.pack_end(self._get_about_button())
 
     def _get_overview_button(self):
         """Return a button to open the ``Overview`` dialog."""
@@ -77,6 +79,12 @@ class HeaderBar(Gtk.HeaderBar):
         """Return a button to bring up the preferences dialog."""
         button = Gtk.Button(_("Preferences"))
         button.connect('clicked', self._on_preferences_button)
+        return button
+
+    def _get_about_button(self):
+        """Return a button to bring up the about dialog."""
+        button = Gtk.Button(_("About"))
+        button.connect('clicked', self._on_about_button)
         return button
 
     def _on_overview_button(self, button):
@@ -96,6 +104,15 @@ class HeaderBar(Gtk.HeaderBar):
             config = dialog.get_config()
             self._app.save_config(config)
         else:
+            pass
+        dialog.destroy()
+
+    def _on_about_button(self, button):
+        """Bring up, process and shut down about dialog."""
+        parent = self.get_parent()
+        dialog = AboutDialog(parent)
+        response = dialog.run()
+        if response == Gtk.ResponseType.OK:
             pass
         dialog.destroy()
 

--- a/hamster_gtk/misc/__init__.py
+++ b/hamster_gtk/misc/__init__.py
@@ -19,4 +19,5 @@
 
 from __future__ import absolute_import, unicode_literals
 
+from .dialogs import HamsterAboutDialog  # NOQA
 from .dialogs import DateRangeSelectDialog, EditFactDialog, ErrorDialog  # NOQA

--- a/hamster_gtk/misc/dialogs.py
+++ b/hamster_gtk/misc/dialogs.py
@@ -26,12 +26,15 @@ from __future__ import absolute_import, unicode_literals
 
 import calendar
 import datetime
+import sys
 from gettext import gettext as _
 
+import hamster_lib
 from gi.repository import Gtk
 from hamster_lib import Fact
 from six import text_type
 
+import hamster_gtk
 from hamster_gtk import helpers
 from hamster_gtk.helpers import _u
 
@@ -347,3 +350,42 @@ class EditFactDialog(Gtk.Dialog):
     def _get_cancel_button(self):
         """Return a *cancel* button."""
         return Gtk.Button.new_from_stock(Gtk.STOCK_CANCEL)
+
+
+class HamsterAboutDialog(Gtk.AboutDialog):
+    """Basic 'About'-dialog class using Gtk default dialog."""
+
+    # Whilst we are not perfectly happy with the layout and general
+    # structure of the dialog it is little effort and works for now.
+    # Alternatively we could either try to customize is to match our
+    # expectations or construct our own from scratch.
+
+    def __init__(self, parent, *args, **kwargs):
+        """Initialize the dialog."""
+        super(HamsterAboutDialog, self).__init__(*args, **kwargs)
+        authors = ['Eric Goller <eric.goller@ninjaduck.solutions>']
+        python_version_string = '{}.{}.{}'.format(
+            sys.version_info.major, sys.version_info.minor, sys.version_info.micro
+        )
+        comments = _(
+            "Thank you for using 'Hamster-GTK.'"
+            " Your current runtime uses 'hamster-lib' {lib_version} and is interpretet by"
+            " Python {python_version}.").format(lib_version=hamster_lib.__version__,
+                                                python_version=python_version_string)
+
+        meta = {
+            'program-name': "Hamster-GTK",
+            'version': hamster_gtk.__version__,
+            'copyright': "Copyright © 2015–2016 Eric Goller / ninjaduck.solutions",
+            'website': "http://projecthamster.org",
+            'website-label': _("Visit Project Hamster Website"),
+            'title': _("About Hamster-GTK"),
+            'license-type': Gtk.License.GPL_3_0,
+            'authors': authors,
+            'comments': comments,
+        }
+
+        for key, value in meta.items():
+            self.set_property(key, value)
+
+        self.show_all()

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -27,9 +27,9 @@ from gettext import gettext as _
 
 from gi.repository import GObject, Gtk
 from hamster_lib import Fact
-from hamster_gtk.helpers import _u
 
 import hamster_gtk.helpers as helpers
+from hamster_gtk.helpers import _u
 
 
 class TrackingScreen(Gtk.Stack):

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -84,7 +84,7 @@ class TestHeaderBar(object):
         assert header_bar.props.title == 'Hamster-GTK'
         assert header_bar.props.subtitle == 'Your friendly time tracker.'
         assert header_bar.props.show_close_button
-        assert len(header_bar.get_children()) == 2
+        assert len(header_bar.get_children()) == 3
 
     def test__get_overview_button(self, header_bar, mocker):
         """Test that that button returned matches expectation."""

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -2,9 +2,9 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import pytest
 from gi.repository import Gtk
 from six import text_type
-import pytest
 
 from hamster_gtk.helpers import _u
 from hamster_gtk.tracking import screens


### PR DESCRIPTION
This PR  adds an *about*-dialog based on GTK's generic ``AboutDialog``
class. Whilst layout, structure and content are not perfect it provides a
out of the box, effortless solution that is good enough for now.

Closes #17
