### PR TITLE
Escape the values inserted as markup

### DIFF
--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -34,7 +34,7 @@ import datetime
 import operator
 from collections import defaultdict, namedtuple
 
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 from hamster_lib import reports
 
 from . import widgets
@@ -258,7 +258,7 @@ class OverviewDialog(Gtk.Dialog):
         box = Gtk.Box
         for category, total in category_totals:
             label = Gtk.Label()
-            label.set_markup("<b>{}:</b> {} minutes".format(category,
+            label.set_markup("<b>{}:</b> {} minutes".format(GObject.markup_escape_text(category),
                                                             int(total.total_seconds() / 60)))
             box.pack_start(label, False, False, 10)
         return box

--- a/hamster_gtk/overview/widgets/fact_grid.py
+++ b/hamster_gtk/overview/widgets/fact_grid.py
@@ -22,7 +22,7 @@
 # have a unicode issue!
 from __future__ import absolute_import
 
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 from hamster_gtk import helpers
 from hamster_gtk.misc.dialogs import EditFactDialog
@@ -61,7 +61,7 @@ class FactGrid(Gtk.Grid):
         date_box.set_name('DayRowDateBox')
         date_label = Gtk.Label()
         date_label.set_name('OverviewDateLabel')
-        date_label.set_markup("<b>{}</b>".format(date_string))
+        date_label.set_markup("<b>{}</b>".format(GObject.markup_escape_text(date_string)))
         date_label.set_valign(Gtk.Align.START)
         date_label.set_justify(Gtk.Justification.RIGHT)
         date_box.add(date_label)
@@ -207,7 +207,8 @@ class FactBox(Gtk.Box):
             category = str(fact.category)
         activity_label = Gtk.Label()
         activity_label.set_markup("{activity} - {category}".format(
-            activity=fact.activity.name, category=category))
+            activity=GObject.markup_escape_text(fact.activity.name),
+            category=GObject.markup_escape_text(category)))
         activity_label.props.halign = Gtk.Align.START
         return activity_label
 
@@ -221,7 +222,7 @@ class FactBox(Gtk.Box):
         """
         def get_tag_widget(name):
             tag_label = Gtk.Label()
-            tag_label.set_markup("<small>{}</small>".format(name))
+            tag_label.set_markup("<small>{}</small>".format(GObject.markup_escape_text(name)))
             tag_label.set_name('OverviewTagLabel')
             tag_box = Gtk.EventBox()
             tag_box.set_name('OverviewTagBox')
@@ -240,6 +241,7 @@ class FactBox(Gtk.Box):
         description_label = Gtk.Label()
         description_label.set_name('OverviewDescriptionLabel')
         description_label.set_line_wrap(True)
-        description_label.set_markup("<small><i>{}</i></small>".format(fact.description))
+        description_label.set_markup("<small><i>{}</i></small>".format(
+            GObject.markup_escape_text(fact.description)))
         description_label.props.halign = Gtk.Align.START
         return description_label

--- a/hamster_gtk/overview/widgets/misc.py
+++ b/hamster_gtk/overview/widgets/misc.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, unicode_literals
 
 from gettext import gettext as _
 
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 from six import text_type
 
 from hamster_gtk.misc.dialogs import DateRangeSelectDialog
@@ -129,6 +129,7 @@ class Summary(Gtk.Box):
 
         for category, total in category_totals:
             label = Gtk.Label()
-            label.set_markup("<b>{}:</b> {} minutes".format(category,
-                                                            int(total.total_seconds() / 60)))
+            label.set_markup("<b>{}:</b> {} minutes".format(
+                GObject.markup_escape_text(text_type(category)),
+                int(total.total_seconds() / 60)))
             self.pack_start(label, False, False, 10)


### PR DESCRIPTION
This commit intruduces proper escaping (via ``GObject.markup_escape_text()``) of string values before they are inserted as label strings.

This should close #78 as well.