### PR TITLE
Fix bumpversion tag creation settng in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 current_version = 0.10.0
 commit = True
-tag = Fakse
+tag = False
 
 [bumpversion:file:setup.py]
 


### PR DESCRIPTION
This PR fixes a typo which invalidated bumpversions ``tag`` option in ``setup.cfg``.