### PR TITLE
[#94] Fix mnemonics in misc.dialogs.

### DIFF
--- a/hamster_gtk/misc/dialogs/date_range_select_dialog.py
+++ b/hamster_gtk/misc/dialogs/date_range_select_dialog.py
@@ -87,7 +87,7 @@ class DateRangeSelectDialog(Gtk.Dialog):
 
     # Widgets
     def _get_apply_button(self):
-        button = Gtk.Button(_('_Apply'))
+        button = Gtk.Button(_('_Apply'), use_underline=True)
         return button
 
     def _get_today_widget(self):

--- a/hamster_gtk/misc/dialogs/edit_fact_dialog.py
+++ b/hamster_gtk/misc/dialogs/edit_fact_dialog.py
@@ -156,12 +156,12 @@ class EditFactDialog(Gtk.Dialog):
 
     def _get_delete_button(self):
         """Return a *delete* button."""
-        return Gtk.Button(_('_Delete'))
+        return Gtk.Button(_('_Delete'), use_underline=True)
 
     def _get_apply_button(self):
         """Return a *apply* button."""
-        return Gtk.Button(_('_Apply'))
+        return Gtk.Button(_('_Apply'), use_underline=True)
 
     def _get_cancel_button(self):
         """Return a *cancel* button."""
-        return Gtk.Button(_('_Cancel'))
+        return Gtk.Button(_('_Cancel'), use_underline=True)


### PR DESCRIPTION
This PR fixes the issue by setting the appropriate ``use_underline`` attribute to enable declaration by *inline underscores*.

Fixes: #94 