### PR TITLE
[#93] Use fixed dark foreground colour for date label in Overview.

### DIFF
--- a/hamster_gtk/resources/css/hamster-gtk.css
+++ b/hamster_gtk/resources/css/hamster-gtk.css
@@ -1,5 +1,6 @@
 #DayRowDateBox {
 	background: #dfdfdf;
+	color: #2e3436;
 }
 
 #OverviewDateLabel {


### PR DESCRIPTION
This PR sets a dark foreground colour (default foreground colour of Adwaita theme), so that the date is legible with every theme.

Fixes: #93