### PR TITLE
[#60] Use helper function for getting parent window reliably 

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -38,7 +38,7 @@ import hamster_lib
 from backports.configparser import SafeConfigParser
 from gi.repository import Gdk, GObject, Gtk
 from hamster_lib.helpers import config_helpers
-from hamster_gtk.helpers import get_resource_path
+from hamster_gtk.helpers import get_parent_window, get_resource_path
 from six import text_type
 
 # [FIXME]
@@ -90,7 +90,7 @@ class HeaderBar(Gtk.HeaderBar):
 
     def _on_overview_button(self, button):
         """Callback for overview button."""
-        parent = self.get_parent()
+        parent = get_parent_window(self)
         OverviewDialog(parent, parent.app)
 
     def _on_preferences_button(self, button):
@@ -98,7 +98,7 @@ class HeaderBar(Gtk.HeaderBar):
         def get_initial():
             """Return current values as a dict."""
             return self._app._config
-        parent = self.get_parent()
+        parent = get_parent_window(self)
         dialog = PreferencesDialog(parent, parent.app, get_initial())
         response = dialog.run()
         if response == Gtk.ResponseType.APPLY:
@@ -110,7 +110,7 @@ class HeaderBar(Gtk.HeaderBar):
 
     def _on_about_button(self, button):
         """Bring up, process and shut down about dialog."""
-        parent = self.get_parent()
+        parent = get_parent_window(self)
         dialog = AboutDialog(parent)
         response = dialog.run()
         if response == Gtk.ResponseType.OK:

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -89,6 +89,25 @@ def clear_children(widget):
     return widget
 
 
+def get_parent_window(widget):
+    """
+    Reliably determine parent window of a widget.
+
+    Just using :meth:`Gtk.Widget.get_toplevel` would return the widget itself
+    if it had no parent window.
+
+    On the other hand using :meth:`Gtk.Widget.get_ancestor` would return only
+    the closest :class:`Gtk.Window` in the hierarchy.
+
+    https://developer.gnome.org/gtk3/unstable/GtkWidget.html#gtk-widget-get-toplevel
+    """
+    toplevel = widget.get_toplevel()
+    if not toplevel.is_toplevel():
+        toplevel = None
+
+    return toplevel
+
+
 def calendar_date_to_datetime(date):
     """Convert :meth:`Gtk.Calendar.get_date` value to :class:`datetime.date`."""
     year, month, day = date

--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -152,7 +152,7 @@ class OverviewDialog(Gtk.Dialog):
         try:
             result = self._app.store.facts.get_all(start, end)
         except (TypeError, ValueError) as error:
-            helpers.show_error(self.get_toplevel(), error)
+            helpers.show_error(helpers.get_parent_window(self), error)
         else:
             return result
 

--- a/hamster_gtk/overview/widgets/fact_grid.py
+++ b/hamster_gtk/overview/widgets/fact_grid.py
@@ -102,7 +102,7 @@ class FactListBox(Gtk.ListBox):
     # Signal callbacks
     def _on_activate(self, widget, row):
         """Callback trigger if a row is 'activated'."""
-        edit_dialog = EditFactDialog(self.get_toplevel(), row.fact)
+        edit_dialog = EditFactDialog(helpers.get_parent_window(self), row.fact)
         response = edit_dialog.run()
         if response == Gtk.ResponseType.CANCEL:
             pass
@@ -117,7 +117,7 @@ class FactListBox(Gtk.ListBox):
         try:
             self._controler.store.facts.save(fact)
         except (ValueError, KeyError) as message:
-            helpers.show_error(self, message)
+            helpers.show_error(helpers.get_parent_window(self), message)
         else:
             self._controler.signal_handler.emit('facts_changed')
 
@@ -126,7 +126,7 @@ class FactListBox(Gtk.ListBox):
         try:
             result = self._controler.store.facts.remove(fact)
         except (ValueError, KeyError) as error:
-            helpers.show_error(self.get_toplevel(), error)
+            helpers.show_error(helpers.get_parent_window(self), error)
         else:
             self._controler.signal_handler.emit('facts_changed')
             return result

--- a/hamster_gtk/overview/widgets/misc.py
+++ b/hamster_gtk/overview/widgets/misc.py
@@ -24,6 +24,7 @@ from gettext import gettext as _
 from gi.repository import GObject, Gtk
 from six import text_type
 
+from hamster_gtk.helpers import get_parent_window
 from hamster_gtk.misc.dialogs import DateRangeSelectDialog
 
 
@@ -73,7 +74,7 @@ class HeaderBar(Gtk.HeaderBar):
     # Callbacks
     def _on_daterange_button_clicked(self, button):
         """Callback for when the 'daterange' button is clicked."""
-        parent = self.get_parent()
+        parent = get_parent_window(self)
         dialog = DateRangeSelectDialog(parent)
         response = dialog.run()
         if response == Gtk.ResponseType.APPLY:
@@ -93,11 +94,11 @@ class HeaderBar(Gtk.HeaderBar):
 
     def _on_previous_daterange_button_clicked(self, button):
         """Callback for when the 'previous' button is clicked."""
-        self.get_parent().apply_previous_daterange()
+        get_parent_window(self).apply_previous_daterange()
 
     def _on_next_daterange_button_clicked(self, button):
         """Callback for when the 'next' button is clicked."""
-        self.get_parent().apply_next_daterange()
+        get_parent_window(self).apply_next_daterange()
 
     def _on_export_button_clicked(self, button):
         """
@@ -106,7 +107,7 @@ class HeaderBar(Gtk.HeaderBar):
         This is the place to run extra logic about where to save/which format.
         ``parent._export_facts`` only deals with the actual export.
         """
-        parent = self.get_parent()
+        parent = get_parent_window(self)
         dialog = Gtk.FileChooserDialog(_("Please Choose where to export to"), parent,
             Gtk.FileChooserAction.SAVE, (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
                                          Gtk.STOCK_SAVE, Gtk.ResponseType.OK))

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -40,7 +40,7 @@ class TrackingScreen(Gtk.Stack):
         super(TrackingScreen, self).__init__()
         self.app = app
 
-        self.main_window = self.get_parent()
+        self.main_window = helpers.get_parent_window(self)
         self.set_transition_type(Gtk.StackTransitionType.SLIDE_UP)
         self.set_transition_duration(1000)
         self.current_fact_view = CurrentFactBox(self.app.controler)
@@ -132,7 +132,7 @@ class CurrentFactBox(Gtk.Box):
         try:
             self._controler.store.facts.cancel_tmp_fact()
         except KeyError as err:
-            helpers.show_error(self.get_toplevel(), err)
+            helpers.show_error(helpers.get_parent_window(self), err)
         else:
             self.emit('tracking-stopped')
 
@@ -145,7 +145,7 @@ class CurrentFactBox(Gtk.Box):
         try:
             self._controler.store.facts.stop_tmp_fact()
         except Exception as error:
-            helpers.show_error(self.get_toplevel(), error)
+            helpers.show_error(helpers.get_parent_window(self), error)
         else:
             self.emit('tracking-stopped')
             # Inform the controller about the chance.
@@ -210,7 +210,7 @@ class StartTrackingBox(Gtk.Box):
         try:
             fact = Fact.create_from_raw_fact(raw_fact)
         except Exception as error:
-            helpers.show_error(self.get_toplevel(), error)
+            helpers.show_error(helpers.get_parent_window(self), error)
         else:
             fact = complete_tmp_fact(fact)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,24 @@
 # -*- coding: utf-8 -*-
 
 import os.path
+
+from gi.repository import Gtk
+
 import hamster_gtk.helpers as helpers
+
+
+def test_get_parent_window_standalone(request):
+    """Make sure the parent window of a windowless widget is None."""
+    label = Gtk.Label('foo')
+    assert helpers.get_parent_window(label) is None
+
+
+def test_get_parent_window(request):
+    """Make sure the parent window of a widget placed in the window is determined correctly."""
+    window = Gtk.Window()
+    label = Gtk.Label('foo')
+    window.add(label)
+    assert helpers.get_parent_window(label) == window
 
 
 def test_get_resource_path(request, file_path):


### PR DESCRIPTION
Just using ``Gtk.Widget.get_toplevel`` would return the widget itself if it had no parent window.

On the other hand using ``Gtk.Widget.get_ancestor`` would return only the closest `Gtk.Window` in the hierarchy.

https://developer.gnome.org/gtk3/unstable/GtkWidget.html#gtk-widget-get-toplevel

Closes: #60