### PR TITLE
Set transient window for AboutDialog

### DIFF
--- a/hamster_gtk/misc/dialogs.py
+++ b/hamster_gtk/misc/dialogs.py
@@ -398,4 +398,5 @@ class HamsterAboutDialog(Gtk.AboutDialog):
         for key, value in meta.items():
             self.set_property(key, value)
 
+        self.set_transient_for(parent)
         self.show_all()


### PR DESCRIPTION
Not setting a transient window is discouraged and Gtk will complain.