### PR TITLE
Use more general python version for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
 	make coverage
 
 [testenv:flake8]
-basepython = python3.4
+basepython = python3
 deps =
     flake8==3.0.4
     flake8-debugger==1.4.0
@@ -24,7 +24,7 @@ skip_install = True
 commands = flake8 setup.py hamster_gtk/ tests/
 
 [testenv:pep257]
-basepython = python3.4
+basepython = python3
 skip_install = True
 deps =
     pep257==0.7.0
@@ -32,20 +32,20 @@ commands =
     pep257 setup.py hamster_gtk/ tests/
 
 [testenv:isort]
-basepython = python3.4
+basepython = python3
 deps = isort==4.2.5
 skip_install = True
 commands =
     isort --check-only --recursive --verbose setup.py hamster_gtk/ tests/
 [testenv:manifest]
-basepython = python3.4
+basepython = python3
 deps = check-manifest==0.31
 skip_install = True
 commands =
     check-manifest -v
 
 [testenv:docs]
-basepython = python3.4
+basepython = python3
 deps = doc8==0.7.0
 commands =
     pip install -r requirements/docs.pip


### PR DESCRIPTION
Use ``python3`` instead of ``python3.4`` in tox environments.