### PR TITLE
[#95] Add 'xvfb' to our test setup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,17 +67,18 @@ lint:
 	flake8 hamster-dbus tests
 
 test:
-	py.test $(TEST_ARGS) tests/
+	xvfb-run py.test $(TEST_ARGS) tests/
 
 test-all:
 	tox
 
 coverage:
-	coverage run -m pytest $(TEST_ARGS) tests
+	xvfb-run coverage run -m pytest $(TEST_ARGS) tests
 	coverage report
 
-test2:
-	py.test tests
+coverage-no-xvfb:
+	coverage run -m pytest $(TEST_ARGS) tests
+	coverage report
 
 coverage-html: coverage
 	coverage html

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,14 @@ rely on it to work properly and most certainly you should not use it in an
 production environment!
 You have been warned.
 
+Dependencies
+-------------
+
+To Run the Testsuite
+~~~~~~~~~~~~~~~~~~~~~
+- make
+- xvfb
+
 First Steps
 ------------
 * Install dependencies (on debian if using virtualenvwrapper):

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,15 @@ envlist = flake8, pep257, manifest
 sitepackages=True
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_gtk
-whitelist_externals = make
+whitelist_externals =
+    make
+    xvfb-run
 passenv =
     SPHINXOPTS_BUILD
     SPHINXOPTS_LINKCHECK
 commands =
 	pip install -r requirements/dev.pip
-	make coverage
+	xvfb-run make coverage-no-xvfb
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
In order to provide a X server environment even on headless systems as
well as preventing to mess the the calling developers running X session
we uses ``xvfb`` to wrap our tests.
While this adds an editional dependency it is one that only matters for
developers, so it is a viable tradeoff.

Closes: #95