### PR TITLE
[#101] Do not show License button in AboutDialog

### DIFF
--- a/hamster_gtk/misc/dialogs/hamster_about_dialog.py
+++ b/hamster_gtk/misc/dialogs/hamster_about_dialog.py
@@ -67,4 +67,3 @@ class HamsterAboutDialog(Gtk.AboutDialog):
             self.set_property(key, value)
 
         self.set_transient_for(parent)
-        self.show_all()


### PR DESCRIPTION
Contemporary Gtk applications do not have License buttons. Instead they provide
link to the license as barely no one reads that stuff.

Hamster accidentally displayed it because it contained forgotten ``show_all()`` call.

Fixes: #101