### PR TITLE
[#105] Make details button insensitive when there are no facts

### DIFF
--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -120,9 +120,9 @@ class OverviewDialog(Gtk.Dialog):
         self.totals_panel = widgets.Summary(self._get_highest_totals(self._totals.category, 3))
         self.main_box.pack_start(self.totals_panel, False, False, 0)
 
-        # [FIXME]
-        # Only show button if there are facts.
         charts_button = Gtk.Button('click to show more details ...')
+        if not self._facts:
+            charts_button.set_sensitive(False)
         charts_button.connect('clicked', self._on_charts_button)
         self.main_box.pack_start(charts_button, False, True, 0)
 


### PR DESCRIPTION
In the Overview dialogue, if there are no facts and the “click to show more details ...” button is pressed an error is raised. To prevent this, the commit desensitizes the button in those cases.

Closes: #105