### PR TITLE
[#109] Remove redundant resfresh of OverviewDialog

### DIFF
--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -66,7 +66,6 @@ class OverviewDialog(Gtk.Dialog):
         self._facts = None
         self._grouped_facts = None
 
-        self.refresh()
         self.show_all()
 
     @property


### PR DESCRIPTION
In `OverviewDialog.__init__` the dialogue was being refreshed twice.

1. By assigning to `self._daterange`.
2. By calling `self.refresh()`.

This commit removes the explicit refresh call as it is redundant.

Closes: #109