### PR TITLE
Harmonize ``facts_changed`` signal name

### DIFF
--- a/hamster_gtk/overview/widgets/fact_grid.py
+++ b/hamster_gtk/overview/widgets/fact_grid.py
@@ -119,7 +119,7 @@ class FactListBox(Gtk.ListBox):
         except (ValueError, KeyError) as message:
             helpers.show_error(helpers.get_parent_window(self), message)
         else:
-            self._controler.signal_handler.emit('facts_changed')
+            self._controler.signal_handler.emit('facts-changed')
 
     def _delete_fact(self, fact):
         """Delete fact from the backend. No further confirmation is required."""
@@ -128,7 +128,7 @@ class FactListBox(Gtk.ListBox):
         except (ValueError, KeyError) as error:
             helpers.show_error(helpers.get_parent_window(self), error)
         else:
-            self._controler.signal_handler.emit('facts_changed')
+            self._controler.signal_handler.emit('facts-changed')
             return result
 
 

--- a/tests/overview/test_widgets.py
+++ b/tests/overview/test_widgets.py
@@ -61,13 +61,13 @@ class TestFactListBox(object):
         assert fact_list_box._update_fact.called
 
     def test__delete_fact(self, request, fact_list_box, fact, mocker):
-        """Make sure that ``facts_changed`` signal is emitted."""
+        """Make sure that ``facts-changed`` signal is emitted."""
         fact_list_box._controler.store.facts.remove = mocker.MagicMock()
         fact_list_box.emit = mocker.MagicMock()
         result = fact_list_box._delete_fact(fact)
         assert fact_list_box._controler.store.facts.remove.called
         assert result is result
-        assert fact_list_box.emit.called_with('facts_changed')
+        assert fact_list_box.emit.called_with('facts-changed')
 
     @pytest.mark.parametrize('exception', (KeyError, ValueError))
     def test__delete_fact_expected_exception(self, request, fact_list_box, exception, fact,


### PR DESCRIPTION
FactListBox emitted ``facts_changed`` signal, even though the SignalHandler recognizes ``facts-changed`` signal. This worked because something translates underscores to dashes.

This signal seems to be the only one using underscores and has now been unified to use dash (Gtk convention).

Closes: #51