### PR TITLE
Changes to config apply to controller at runtime(#62)

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -176,7 +176,9 @@ class HamsterGTK(Gtk.Application):
         self.window = None
         # Which config backend to use.
         self.config_store = 'file'
-        self.config = self._reload_config()
+        # Yes this is redundent, but more transparent. And we can worry about
+        # this unwarrented assignment once it actually matters.
+        self._config = self._reload_config()
 
         self.connect('startup', self._startup)
         self.connect('activate', self._activate)
@@ -239,11 +241,7 @@ class HamsterGTK(Gtk.Application):
 
     def _config_changed(self, sender):
         """Callback triggered when config has been changed."""
-        self._reload_config()
-        # [FIXME]
-        # hamster-lib currentl provides no proper way to update its config
-        # See: https://github.com/projecthamster/hamster-lib/issues/190
-        # We want something like ``self.controler.update_config(self._config)``
+        self.controler.update_config(self._reload_config())
 
     def _get_default_config(self):
         """

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -59,6 +59,14 @@ class TestHamsterGTK(object):
         assert result['db_engine'] == cp_instance.get('Backend', 'db_engine')
         assert result['db_path'] == cp_instance.get('Backend', 'db_path')
 
+    def test__config_changed(self, app, config, mocker):
+        """Make sure the controler *and* client config is updated."""
+        app._reload_config = mocker.MagicMock(return_value=config)
+        app.controler.update_config = mocker.MagicMock()
+        app._config_changed(None)
+        assert app._reload_config.called
+        assert app.controler.update_config.called_with(config)
+
 
 class TestMainWindow(object):
     """Unittests for the main application window."""


### PR DESCRIPTION
The ``config_changed`` call back now uses the controllers
``update_config`` method to pass along the new config, hence triggering
a backend config update at runtime.
We also normalized the attribute in which the application stores the
config dict to ``HamsterGTK._config`` (Previously ``config`` and
``_config`` were used.

Closes: #62