### PR TITLE
Replace 'controler' with 'controller'

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -196,19 +196,19 @@ class HamsterGTK(Gtk.Application):
         """
         cp_instance = self._config_to_configparser(config)
         config_helpers.write_config_file(cp_instance, 'hamster-gtk', 'hamster-gtk.conf')
-        self.controler.signal_handler.emit('config-changed')
+        self.controller.signal_handler.emit('config-changed')
 
     def _startup(self, app):
         """Triggered right at startup."""
         print(_('Hamster-GTK started.'))  # NOQA
         self._reload_config()
-        self.controler = hamster_lib.HamsterControl(self._config)
-        self.controler.signal_handler = SignalHandler()
-        self.controler.signal_handler.connect('config-changed', self._config_changed)
+        self.controller = hamster_lib.HamsterControl(self._config)
+        self.controller.signal_handler = SignalHandler()
+        self.controller.signal_handler.connect('config-changed', self._config_changed)
         # For convenience only
         # [FIXME]
         # Pick one canonical path and stick to it!
-        self.store = self.controler.store
+        self.store = self.controller.store
 
         # Reference to any existing overview dialog.
         self.overview = None
@@ -241,7 +241,7 @@ class HamsterGTK(Gtk.Application):
 
     def _config_changed(self, sender):
         """Callback triggered when config has been changed."""
-        self.controler.update_config(self._reload_config())
+        self.controller.update_config(self._reload_config())
 
     def _get_default_config(self):
         """

--- a/hamster_gtk/overview/dialogs.py
+++ b/hamster_gtk/overview/dialogs.py
@@ -50,7 +50,7 @@ class OverviewDialog(Gtk.Dialog):
         """Initialize dialog."""
         super(OverviewDialog, self).__init__(*args, **kwargs)
         self.set_transient_for(parent)
-        self.titlebar = widgets.HeaderBar(app.controler)
+        self.titlebar = widgets.HeaderBar(app.controller)
         self._parent = parent
         self._app = app
         self._connect_signals()
@@ -79,13 +79,14 @@ class OverviewDialog(Gtk.Dialog):
     def _daterange(self, daterange):
         """Set daterange and make sure we emit the corresponding signal."""
         self.__daterange = daterange
-        self._app.controler.signal_handler.emit('daterange-changed', self.__daterange)
+        self._app.controller.signal_handler.emit('daterange-changed', self.__daterange)
 
     def _connect_signals(self):
         """Connect signals this instance listens for."""
-        self._app.controler.signal_handler.connect('config-changed', self._on_config_changed)
-        self._app.controler.signal_handler.connect('facts-changed', self._on_facts_changed)
-        self._app.controler.signal_handler.connect('daterange-changed', self._on_daterange_changed)
+        self._app.controller.signal_handler.connect('config-changed', self._on_config_changed)
+        self._app.controller.signal_handler.connect('facts-changed', self._on_facts_changed)
+        self._app.controller.signal_handler.connect('daterange-changed',
+            self._on_daterange_changed)
 
     def _get_default_daterange(self):
         """Return the default daterange used when none has been selected by user."""
@@ -114,7 +115,7 @@ class OverviewDialog(Gtk.Dialog):
             self._charts = False
 
         facts_window = Gtk.ScrolledWindow()
-        self.factlist = widgets.FactGrid(self._app.controler, self._grouped_facts.by_date)
+        self.factlist = widgets.FactGrid(self._app.controller, self._grouped_facts.by_date)
         facts_window.add(self.factlist)
         self.main_box.pack_start(facts_window, True, True, 0)
 

--- a/hamster_gtk/overview/widgets/fact_grid.py
+++ b/hamster_gtk/overview/widgets/fact_grid.py
@@ -31,7 +31,7 @@ from hamster_gtk.misc.dialogs import EditFactDialog
 class FactGrid(Gtk.Grid):
     """Listing of facts per day."""
 
-    def __init__(self, controler, initial, *args, **kwargs):
+    def __init__(self, controller, initial, *args, **kwargs):
         """
         Initialize widget.
 
@@ -46,7 +46,7 @@ class FactGrid(Gtk.Grid):
         for date, facts in initial.items():
             # [FIXME] Order by fact start
             self.attach(self._get_date_widget(date), 0, row, 1, 1)
-            self.attach(self._get_fact_list(controler, facts), 1, row, 1, 1)
+            self.attach(self._get_fact_list(controller, facts), 1, row, 1, 1)
             row += 1
 
     def _get_date_widget(self, date):
@@ -67,7 +67,7 @@ class FactGrid(Gtk.Grid):
         date_box.add(date_label)
         return date_box
 
-    def _get_fact_list(self, controler, facts):
+    def _get_fact_list(self, controller, facts):
         """
         Return a widget representing all of the dates facts.
 
@@ -76,19 +76,19 @@ class FactGrid(Gtk.Grid):
         ``Gtk.ListBox`` keyboard and mouse navigation / event handling.
         """
         # [FIXME]
-        # It would be preferable to not have to pass the controler instance
+        # It would be preferable to not have to pass the controller instance
         # through all the way, but for now it will do.
-        return FactListBox(controler, facts)
+        return FactListBox(controller, facts)
 
 
 class FactListBox(Gtk.ListBox):
     """A List widget that represents each fact in a seperate actionable row."""
 
-    def __init__(self, controler, facts):
+    def __init__(self, controller, facts):
         """Initialize widget."""
         super(FactListBox, self).__init__()
 
-        self._controler = controler
+        self._controller = controller
 
         self.set_name('OverviewFactList')
         self.set_selection_mode(Gtk.SelectionMode.SINGLE)
@@ -115,20 +115,20 @@ class FactListBox(Gtk.ListBox):
     def _update_fact(self, fact):
         """Update the a fact with values from edit dialog."""
         try:
-            self._controler.store.facts.save(fact)
+            self._controller.store.facts.save(fact)
         except (ValueError, KeyError) as message:
             helpers.show_error(helpers.get_parent_window(self), message)
         else:
-            self._controler.signal_handler.emit('facts-changed')
+            self._controller.signal_handler.emit('facts-changed')
 
     def _delete_fact(self, fact):
         """Delete fact from the backend. No further confirmation is required."""
         try:
-            result = self._controler.store.facts.remove(fact)
+            result = self._controller.store.facts.remove(fact)
         except (ValueError, KeyError) as error:
             helpers.show_error(helpers.get_parent_window(self), error)
         else:
-            self._controler.signal_handler.emit('facts-changed')
+            self._controller.signal_handler.emit('facts-changed')
             return result
 
 

--- a/hamster_gtk/overview/widgets/misc.py
+++ b/hamster_gtk/overview/widgets/misc.py
@@ -31,7 +31,7 @@ from hamster_gtk.misc.dialogs import DateRangeSelectDialog
 class HeaderBar(Gtk.HeaderBar):
     """Headerbar used by the overview screen."""
 
-    def __init__(self, controler, *args, **kwargs):
+    def __init__(self, controller, *args, **kwargs):
         """Initialize headerbar."""
         super(HeaderBar, self).__init__(*args, **kwargs)
         self.set_show_close_button(True)
@@ -42,7 +42,7 @@ class HeaderBar(Gtk.HeaderBar):
         self.pack_start(self._daterange_button)
         self.pack_end(self._get_export_button())
 
-        controler.signal_handler.connect('daterange-changed', self._on_daterange_changed)
+        controller.signal_handler.connect('daterange-changed', self._on_daterange_changed)
 
     # Widgets
     def _get_export_button(self):

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -43,9 +43,9 @@ class TrackingScreen(Gtk.Stack):
         self.main_window = helpers.get_parent_window(self)
         self.set_transition_type(Gtk.StackTransitionType.SLIDE_UP)
         self.set_transition_duration(1000)
-        self.current_fact_view = CurrentFactBox(self.app.controler)
+        self.current_fact_view = CurrentFactBox(self.app.controller)
         self.current_fact_view.connect('tracking-stopped', self.update)
-        self.start_tracking_view = StartTrackingBox(self.app.controler)
+        self.start_tracking_view = StartTrackingBox(self.app.controller)
         self.start_tracking_view.connect('tracking-started', self.update)
         self.add_titled(self.start_tracking_view, 'start tracking', _("Start Tracking"))
         self.add_titled(self.current_fact_view, 'ongoing fact', _("Show Ongoing Fact"))
@@ -59,7 +59,7 @@ class TrackingScreen(Gtk.Stack):
         This depends on wether there exists an *ongoing fact* or not.
         """
         try:
-            current_fact = self.app.controler.store.facts.get_tmp_fact()
+            current_fact = self.app.controller.store.facts.get_tmp_fact()
         except KeyError:
             self.start_tracking_view.show()
             self.set_visible_child(self.start_tracking_view)
@@ -77,13 +77,13 @@ class CurrentFactBox(Gtk.Box):
         str('tracking-stopped'): (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, ()),
     }
 
-    def __init__(self, controler):
+    def __init__(self, controller):
         """Setup widget."""
         # We need to wrap this in a vbox to limit its vertical expansion.
         # [FIXME]
         # Switch to Grid based layout.
         super(CurrentFactBox, self).__init__(orientation=Gtk.Orientation.VERTICAL, spacing=10)
-        self._controler = controler
+        self._controller = controller
         self.content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.pack_start(self.content, False, False, 0)
 
@@ -94,7 +94,7 @@ class CurrentFactBox(Gtk.Box):
 
         if not fact:
             try:
-                fact = self._controler.store.facts.get_tmp_fact()
+                fact = self._controller.store.facts.get_tmp_fact()
             except KeyError:
                 # This should never be seen by the user. It would mean that a
                 # switch to this screen has been triggered without an ongoing
@@ -130,7 +130,7 @@ class CurrentFactBox(Gtk.Box):
         Discard current *ongoing fact* without saving.
         """
         try:
-            self._controler.store.facts.cancel_tmp_fact()
+            self._controller.store.facts.cancel_tmp_fact()
         except KeyError as err:
             helpers.show_error(helpers.get_parent_window(self), err)
         else:
@@ -143,13 +143,13 @@ class CurrentFactBox(Gtk.Box):
         Save *ongoing fact* to storage.
         """
         try:
-            self._controler.store.facts.stop_tmp_fact()
+            self._controller.store.facts.stop_tmp_fact()
         except Exception as error:
             helpers.show_error(helpers.get_parent_window(self), error)
         else:
             self.emit('tracking-stopped')
             # Inform the controller about the chance.
-            self._controler.signal_handler.emit('facts-changed')
+            self._controller.signal_handler.emit('facts-changed')
 
 
 class StartTrackingBox(Gtk.Box):
@@ -162,11 +162,11 @@ class StartTrackingBox(Gtk.Box):
     # [FIXME]
     # Switch to Grid based layout.
 
-    def __init__(self, controler, *args, **kwargs):
+    def __init__(self, controller, *args, **kwargs):
         """Setup widget."""
         super(StartTrackingBox, self).__init__(orientation=Gtk.Orientation.VERTICAL,
                                                spacing=10, *args, **kwargs)
-        self._controler = controler
+        self._controller = controller
         self.set_homogeneous(False)
 
         # [FIXME]
@@ -215,12 +215,12 @@ class StartTrackingBox(Gtk.Box):
             fact = complete_tmp_fact(fact)
 
             try:
-                fact = self._controler.store.facts.save(fact)
+                fact = self._controller.store.facts.save(fact)
             except Exception as error:
                 helpers.show_error(self.get_top_level(), error)
             else:
                 self.emit('tracking-started')
-                self._controler.signal_handler.emit('facts-changed')
+                self._controller.signal_handler.emit('facts-changed')
                 self.reset()
 
     def reset(self):

--- a/tests/overview/conftest.py
+++ b/tests/overview/conftest.py
@@ -28,13 +28,13 @@ def fact_grid(request, app):
     Note:
         This instance does not have a parent associated.
     """
-    return widgets.fact_grid.FactGrid(app.controler, {})
+    return widgets.fact_grid.FactGrid(app.controller, {})
 
 
 @pytest.fixture
 def fact_list_box(request, app, set_of_facts):
     """Return a FactListBox with random facts."""
-    return widgets.fact_grid.FactListBox(app.controler, set_of_facts)
+    return widgets.fact_grid.FactListBox(app.controller, set_of_facts)
 
 
 @pytest.fixture

--- a/tests/overview/test_widgets.py
+++ b/tests/overview/test_widgets.py
@@ -15,7 +15,7 @@ class TestFactGrid(object):
 
     def test_init(self, app):
         """Make sure minimal initialisation works."""
-        fact_grid = widgets.FactGrid(app.controler, {})
+        fact_grid = widgets.FactGrid(app.controller, {})
         assert fact_grid
 
     def test__get_date_widget(self, fact_grid):
@@ -25,7 +25,7 @@ class TestFactGrid(object):
 
     def test__get_fact_list(self, app, fact_grid):
         """Make sure a FactListBox is retuned."""
-        result = fact_grid._get_fact_list(app.controler, [])
+        result = fact_grid._get_fact_list(app.controller, [])
         assert isinstance(result, widgets.fact_grid.FactListBox)
 
 
@@ -34,7 +34,7 @@ class TestFactListBox(object):
 
     def test_init(self, app, set_of_facts):
         """Test that instantiation works as expected."""
-        result = widgets.fact_grid.FactListBox(app.controler, set_of_facts)
+        result = widgets.fact_grid.FactListBox(app.controller, set_of_facts)
         assert isinstance(result, widgets.fact_grid.FactListBox)
         assert len(result.get_children()) == len(set_of_facts)
 
@@ -62,10 +62,10 @@ class TestFactListBox(object):
 
     def test__delete_fact(self, request, fact_list_box, fact, mocker):
         """Make sure that ``facts-changed`` signal is emitted."""
-        fact_list_box._controler.store.facts.remove = mocker.MagicMock()
+        fact_list_box._controller.store.facts.remove = mocker.MagicMock()
         fact_list_box.emit = mocker.MagicMock()
         result = fact_list_box._delete_fact(fact)
-        assert fact_list_box._controler.store.facts.remove.called
+        assert fact_list_box._controller.store.facts.remove.called
         assert result is result
         assert fact_list_box.emit.called_with('facts-changed')
 
@@ -73,7 +73,7 @@ class TestFactListBox(object):
     def test__delete_fact_expected_exception(self, request, fact_list_box, exception, fact,
             mocker):
         """Make sure that we show error dialog if we encounter an expected exception."""
-        fact_list_box._controler.store.facts.remove = mocker.MagicMock(side_effect=exception)
+        fact_list_box._controller.store.facts.remove = mocker.MagicMock(side_effect=exception)
         show_error = mocker.patch('hamster_gtk.overview.widgets.fact_grid.helpers.show_error')
         fact_list_box.emit = mocker.MagicMock()
         result = fact_list_box._delete_fact(fact)
@@ -83,7 +83,7 @@ class TestFactListBox(object):
 
     def test__delete_fact_unexpected_exception(self, request, fact_list_box, fact, mocker):
         """Make sure that we do not intercept unexpected exceptions."""
-        fact_list_box._controler.store.facts.remove = mocker.MagicMock(side_effect=Exception)
+        fact_list_box._controller.store.facts.remove = mocker.MagicMock(side_effect=Exception)
         with pytest.raises(Exception):
             fact_list_box._on_cancel_button(fact)
 

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -60,12 +60,12 @@ class TestHamsterGTK(object):
         assert result['db_path'] == cp_instance.get('Backend', 'db_path')
 
     def test__config_changed(self, app, config, mocker):
-        """Make sure the controler *and* client config is updated."""
+        """Make sure the controller *and* client config is updated."""
         app._reload_config = mocker.MagicMock(return_value=config)
-        app.controler.update_config = mocker.MagicMock()
+        app.controller.update_config = mocker.MagicMock()
         app._config_changed(None)
         assert app._reload_config.called
-        assert app.controler.update_config.called_with(config)
+        assert app.controller.update_config.called_with(config)
 
 
 class TestMainWindow(object):

--- a/tests/tracking/conftest.py
+++ b/tests/tracking/conftest.py
@@ -18,10 +18,10 @@ def tracking_screen(request, app):
 @pytest.fixture
 def start_tracking_box(request, app):
     """Provide a plain StartTrackingBox instance."""
-    return screens.StartTrackingBox(app.controler)
+    return screens.StartTrackingBox(app.controller)
 
 
 @pytest.fixture
 def current_fact_box(request, app):
     """Provide a plain CurrentFactBox instance."""
-    return screens.CurrentFactBox(app.controler)
+    return screens.CurrentFactBox(app.controller)

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -22,7 +22,7 @@ class TestTrackingScreen(object):
     def test_update_with_ongoing_fact(self, tracking_screen, fact, mocker):
         """Make sure current fact view is shown."""
         fact.end is None
-        tracking_screen.app.controler.store.facts.get_tmp_fact = mocker.MagicMock(
+        tracking_screen.app.controller.store.facts.get_tmp_fact = mocker.MagicMock(
             return_value=fact)
         tracking_screen.update()
         result = tracking_screen.get_visible_child()
@@ -31,7 +31,7 @@ class TestTrackingScreen(object):
 
     def test_update_with_no_ongoing_fact(self, tracking_screen, mocker):
         """Make sure start tracking view is shown."""
-        tracking_screen.app.controler.store.facts.get_tmp_fact = mocker.MagicMock(
+        tracking_screen.app.controller.store.facts.get_tmp_fact = mocker.MagicMock(
             side_effect=KeyError)
         tracking_screen.update()
         result = tracking_screen.get_visible_child()
@@ -44,7 +44,7 @@ class TestStartTrackingBox(object):
 
     def test_init(self, app):
         """Make sure instances matches expectation."""
-        result = screens.StartTrackingBox(app.controler)
+        result = screens.StartTrackingBox(app.controller)
         assert isinstance(result, screens.StartTrackingBox)
         assert len(result.get_children()) == 3
 
@@ -52,11 +52,11 @@ class TestStartTrackingBox(object):
         """Make sure a new 'ongoing fact' is created."""
         # [FIXME]
         # We need to find a viable way to check if signals are emitted!
-        start_tracking_box._controler.store.facts.save = mocker.MagicMock()
+        start_tracking_box._controller.store.facts.save = mocker.MagicMock()
         raw_fact = '{fact.activity.name}@{fact.category.name}'.format(fact=fact)
         start_tracking_box.raw_fact_entry.props.text = raw_fact
         start_tracking_box._on_start_tracking_button(None)
-        assert start_tracking_box._controler.store.facts.save.called
+        assert start_tracking_box._controller.store.facts.save.called
 
     def test__reset(self, start_tracking_box):
         """Make sure all relevant widgets are reset."""
@@ -69,7 +69,7 @@ class TestCurrentFactBox(object):
     """Unittests for CurrentFactBox."""
 
     def test_init(self, app):
-        result = screens.CurrentFactBox(app.controler)
+        result = screens.CurrentFactBox(app.controller)
         assert isinstance(result, screens.CurrentFactBox)
 
     def test_update_initial_fact(self, current_fact_box, fact):
@@ -104,16 +104,16 @@ class TestCurrentFactBox(object):
 
     def test_on_cancel_buton(self, request, current_fact_box, mocker):
         """Make sure that 'tracking-stopped' signal is emitted."""
-        current_fact_box._controler.store.facts.cancel_tmp_fact = mocker.MagicMock()
+        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock()
         current_fact_box.emit = mocker.MagicMock()
         result = current_fact_box._on_cancel_button(None)
-        assert current_fact_box._controler.store.facts.cancel_tmp_fact.called
+        assert current_fact_box._controller.store.facts.cancel_tmp_fact.called
         assert result is None
         assert current_fact_box.emit.called_with('tracking-stopped')
 
     def test_on_cancel_buton_expected_exception(self, request, current_fact_box, mocker):
         """Make sure that we show error dialog if we encounter an expected exception."""
-        current_fact_box._controler.store.facts.cancel_tmp_fact = mocker.MagicMock(
+        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
             side_effect=KeyError)
         show_error = mocker.patch('hamster_gtk.tracking.screens.helpers.show_error')
         current_fact_box.emit = mocker.MagicMock()
@@ -124,7 +124,7 @@ class TestCurrentFactBox(object):
 
     def test_on_cancel_buton_unexpected_exception(self, request, current_fact_box, mocker):
         """Make sure that we do not intercept unexpected exceptions."""
-        current_fact_box._controler.store.facts.cancel_tmp_fact = mocker.MagicMock(
+        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
             side_effect=Exception)
         with pytest.raises(Exception):
             current_fact_box._on_cancel_button(None)


### PR DESCRIPTION
This commit replaces incorrectly spelled 'controler' with 'controller' throughout the codebase.

Closes: #47
