### PR TITLE
[#118] Rearrange Preferences into tabs

### DIFF
--- a/hamster_gtk/preferences/widgets/__init__.py
+++ b/hamster_gtk/preferences/widgets/__init__.py
@@ -21,4 +21,5 @@ from .combo_file_chooser import ComboFileChooser  # NOQA
 from .config_widget import ConfigWidget  # NOQA
 from .hamster_combo_box_text import HamsterComboBoxText  # NOQA
 from .hamster_spin_button import HamsterSpinButton, SimpleAdjustment  # NOQA
+from .preferences_grid import PreferencesGrid  # NOQA
 from .time_entry import TimeEntry  # NOQA

--- a/hamster_gtk/preferences/widgets/preferences_grid.py
+++ b/hamster_gtk/preferences/widgets/preferences_grid.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides a Grid for easy construction of preference screens."""
+
+from __future__ import absolute_import
+
+from gi.repository import Gtk
+
+
+class PreferencesGrid(Gtk.Grid):
+    """A widget which arranges labelled fields automatically."""
+
+    # Required else you would need to specify the full module name in ui file
+    __gtype_name__ = 'PreferencesGrid'
+
+    def __init__(self, fields=None):
+        """
+        Initialize widget.
+
+        Args:
+            fields (collections.OrderedDict): Ordered dictionary of {key, (label, widget)}.
+        """
+        super(Gtk.Grid, self).__init__()
+
+        if fields:
+            self._fields = fields
+        else:
+            self._fields = {}
+
+        row = 0
+        for key, (label, widget) in self._fields.items():
+            label_widget = Gtk.Label(label)
+            label_widget.set_use_underline(True)
+            label_widget.set_mnemonic_widget(widget)
+            self.attach(label_widget, 0, row, 1, 1)
+            self.attach(widget, 1, row, 1, 1)
+            row += 1
+
+    def get_values(self):
+        """
+        Parse config widgets and construct a {field: value} dict.
+
+        Returns:
+            dict: Dictionary of config keys/values.
+        """
+        result = {}
+        for key, (label, widget) in self._fields.items():
+            result[key] = widget.get_config_value()
+
+        return result
+
+    def set_values(self, values):
+        """
+        Go through widgets and set their values.
+
+        Args:
+            values (dict): Dictionary of config keys/values
+        """
+        for key, (label, widget) in self._fields.items():
+            widget.set_config_value(values.get(key, ''))

--- a/hamster_gtk/resources/css/hamster-gtk.css
+++ b/hamster_gtk/resources/css/hamster-gtk.css
@@ -38,3 +38,8 @@
 #EditDialogMainBox {
 	padding: 15px;
 }
+
+/*PreferencesDialog*/
+#PreferencesNotebook {
+	margin-bottom: 0.5em;
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,12 +74,6 @@ def dummy_window(request):
     return Gtk.Window()
 
 
-@pytest.fixture
-def preferences_dialog(request, dummy_window, app, config):
-    """Return plain PreferencesDialog instance."""
-    return hamster_gtk.PreferencesDialog(dummy_window, app, config)
-
-
 @pytest.fixture(params=(
     fauxfactory.gen_string('utf8'),
     fauxfactory.gen_string('cjk'),

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -5,13 +5,16 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
+import collections
 
 import fauxfactory
 import pytest
 
+from hamster_gtk.preferences.preferences_dialog import PreferencesDialog
+from hamster_gtk.preferences import widgets
+
 
 # Data
-
 @pytest.fixture(params=('sqlalchemy',))
 def store_parametrized(request):
     """Return a parametrized store value."""
@@ -66,7 +69,7 @@ def db_path_parametrized(request, tmpdir):
 
 
 @pytest.fixture
-def initial_config_parametrized(request, store_parametrized, day_start_parametrized,
+def config_parametrized(request, store_parametrized, day_start_parametrized,
         fact_min_delta_parametrized, tmpfile_path_parametrized, db_engine_parametrized,
         db_path_parametrized):
             """Return a config fixture with heavily parametrized config values."""
@@ -78,3 +81,27 @@ def initial_config_parametrized(request, store_parametrized, day_start_parametri
                 'db_engine': db_engine_parametrized,
                 'db_path': db_path_parametrized,
             }
+
+
+@pytest.fixture
+def preference_page_fields(request):
+    """Return a static dict of valid fields suitable to be consumed by ``PreferenceGrid``."""
+    return collections.OrderedDict((
+        ('store', ('_Store', widgets.HamsterComboBoxText([]))),
+        ('db_engine', ('DB _Engine', widgets.HamsterComboBoxText([]))),
+        ('db_path', ('DB _Path', widgets.ComboFileChooser())),
+        ('tmpfile_path', ('_Temporary file', widgets.ComboFileChooser())),
+    ))
+
+
+# Instances
+@pytest.fixture
+def preferences_dialog(request, dummy_window, app, config):
+    """Return a ``PreferenceDialog`` instance."""
+    return PreferencesDialog(dummy_window, app, config)
+
+
+@pytest.fixture
+def preferences_grid(request, preference_page_fields):
+    """Return a ``PreferenceGrid`` instance."""
+    return widgets.PreferencesGrid(preference_page_fields)

--- a/tests/preferences/test_preferences_dialog.py
+++ b/tests/preferences/test_preferences_dialog.py
@@ -2,34 +2,43 @@
 
 from __future__ import unicode_literals
 
+import pytest
+
 from hamster_gtk.preferences import PreferencesDialog
 
 
 class TestPreferencesDialog(object):
     """Unittests for PreferencesDialog."""
 
-    def test_init(self, dummy_window, app, config):
+    @pytest.mark.parametrize('empty_initial', (True, False))
+    def test_init(self, dummy_window, app, config, empty_initial):
         """Make instantiation works as expected."""
+        if empty_initial:
+            config = {}
         result = PreferencesDialog(dummy_window, app, config)
-        grid = result.get_content_area().get_children()[0]
+        grids = result.get_content_area().get_children()[0].get_children()
         # This assumes 2 children per config entry (label and widget).
-        assert len(grid.get_children()) / 2 == len(config.keys())
+        grid_entry_counts = [len(g.get_children()) / 2 for g in grids]
+        assert sum(grid_entry_counts) == 6
 
-    def test_get_config(self, dummy_window, app, initial_config_parametrized):
+    def test_get_config(self, preferences_dialog, config_parametrized):
         """
         Make sure retrieval of field values works as expected.
 
         In particular we need to make sure that unicode/utf-8 handling works as
         expected.
         """
-        dialog = PreferencesDialog(dummy_window, app, initial_config_parametrized)
-        result = dialog.get_config()
-        assert result == initial_config_parametrized
+        preferences_dialog._set_config(config_parametrized)
+        result = preferences_dialog.get_config()
+        assert result == config_parametrized
 
-    def test_set_config(self, dummy_window, app, initial_config_parametrized):
+    def test_set_config(self, preferences_dialog, config_parametrized):
         """Make sure setting the field values works as expected."""
-        dialog = PreferencesDialog(dummy_window, app, initial_config_parametrized)
-        another_config_parametrized = initial_config_parametrized
-        dialog._set_config(another_config_parametrized)
-        for key, (_label, widget) in dialog._fields.items():
-            assert widget.get_config_value() == initial_config_parametrized[key]
+        preferences_dialog._set_config(config_parametrized)
+        for title, page in preferences_dialog._pages:
+            for key, (label, widget) in page._fields.items():
+                assert widget.get_config_value() == config_parametrized[key]
+
+    def test_set_config_empty_value(self, preferences_dialog):
+        with pytest.raises(ValueError):
+            preferences_dialog._set_config({})

--- a/tests/preferences/widgets/test_preferences_grid.py
+++ b/tests/preferences/widgets/test_preferences_grid.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+import pytest
+
+from hamster_gtk.preferences.widgets import PreferencesGrid
+
+
+@pytest.mark.parametrize('no_fields', (True, False))
+def test_init(preference_page_fields, no_fields):
+    """Make sure instantiation works with and without fields provided."""
+    if no_fields:
+        grid = PreferencesGrid()
+        assert grid._fields == {}
+    else:
+        grid = PreferencesGrid(preference_page_fields)
+        assert grid._fields == preference_page_fields
+    rows = len(grid.get_children()) / 2
+    assert rows == len(grid._fields)
+
+
+def test_get_values(preferences_grid, preference_page_fields, mocker):
+    """Make sure widget fetches values for all its sub-widgets."""
+    for key, (label, widget) in preference_page_fields.items():
+        widget.get_config_value = mocker.MagicMock()
+    preferences_grid.get_values()
+    for key, (label, widget) in preference_page_fields.items():
+        assert widget.get_config_value.called
+
+
+def test_set_values(preferences_grid, preference_page_fields, mocker):
+    """Make sure widget sets values for all its sub-widgets."""
+    for key, (label, widget) in preference_page_fields.items():
+        widget.set_config_value = mocker.MagicMock()
+    preferences_grid.set_values(preference_page_fields)
+    for key, (label, widget) in preference_page_fields.items():
+        assert widget.set_config_value.called


### PR DESCRIPTION
This commit splits Preferences fields into different categories
(Tracking, Storage), each represented by a Gtk.Stack tab.

While it might seem moot to split them with this little fields,
it will be a base for adding other preferences widgets like
activity/category/tag manager.

Closes: #118
