### PR TITLE
[#25] Re-enable autodoc for Sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ addons:
     - python-cairo
     - python-gi-cairo
     # - python3-gobject Provided by python3-gi
-    #- python3-gi
-    #- python3-cairo
-    #- python3-gi-cairo
+    - python3-gi
+    - python3-cairo
+    - python3-gi-cairo
 
 virtualenv:
   system_site_packages: true
@@ -38,6 +38,8 @@ install:
   - pip install --upgrade pip
   - pip install -r requirements/test.pip
   - sudo apt-get install --only-upgrade libgtk-3-dev
+  # Trusty only provides modules for Python 3.4, they will, however, work even with newer versions.
+  - sudo ln -s /usr/lib/python3/dist-packages/gi/_gi.cpython-34m-x86_64-linux-gnu.so /usr/lib/python3/dist-packages/gi/_gi.so
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,10 @@ import shlex
 cwd = os.getcwd()
 project_root = os.path.dirname(cwd)
 
+# On Travis python3-gi is installed into folllowing directory, which
+# is not added to path because Travis uses virtualenv.
+sys.path.insert(0, '/usr/lib/python3/dist-packages')
+
 # Insert the project root dir as the first element in the PYTHONPATH.
 # This lets us ensure that the source package is imported, and that its
 # version is used.
@@ -43,7 +47,8 @@ import hamster_gtk
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    #'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,7 @@ commands =
 [testenv:docs]
 basepython = python3
 deps = doc8==0.7.0
+sitepackages = True
 commands =
     pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}


### PR DESCRIPTION
Finally managed to tack this. There are actually two problems:
1. Global packages are not added to tox’s environment
2. `_gi.cpython-34m-x86_64-linux-gnu.so` is not recognized as `_gi`.

Both solutions are kinda hacky but after several hours I was not able to come up with anything better.

I am not sure whether to include the second commit. Personally I would delete the files and add them to `.gitignore` as they are generated automatically, but `hamster_gtk.rst` was already committed so I committed the rest too.

The tests are failing due to invalid links (#126).

Relates to: #25 
