### PR TITLE
[#132] Fix excessive line length within documentation.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,15 +6,15 @@ History
 0.11.0 (2016-10-03)
 --------------------
 - Config changes are now applied at runtime (Fixes: #57).
-- ``PreferencesDialog`` and its widgets moved to seperate sub-package (PR: #83).
+- ``PreferencesDialog`` and its widgets moved to separate subpackage (PR: #83).
 - ``facts_changed`` Signal has been renamed to ``facts-changed`` (Fixes: #51).
 - ``Overview._charts`` gets destroyed on ``refresh`` (Closes: #106).
-- *Show more* button in overview is inactive if there are no facts at all (Closes: #105).
-- Improved contrast for ``date colour`` in overview with dark themes (Closes: #93).
-- ``hamster_gtk.misc.dialogs`` has been split into multiple sub-modules (Closes: #96).
+- Overview: *Show more* button is inactive if there are no facts (Fixes: #105).
+- Overview: Improve ``date colour`` contrast with dark themes (Closes: #93).
+- Split ``hamster_gtk.misc.dialogs`` into multiple sub-modules (Closes: #96).
 - Test setup makes use of ``xvfb`` (Closes: #95).
-- ``tox`` tests against ``python3`` instead more specific python 3 versions (PR: #92).
-- Add new helper function ``hamster_gtk.helpers.get_parent_window`` (Closes: #60).
+- Test ``tox`` against ``python3`` instead of more specific versions (PR: #92).
+- Add new helper function ``get_parent_window`` (Closes: #60).
 - Fix ``EditDialog`` for uncategoriezed facts (Closes: #59).
 - Replace GTK stock buttons with generic label buttons (Closes: #46).
 - Escape values inserted as markup (Closes: #78).

--- a/README.rst
+++ b/README.rst
@@ -33,30 +33,31 @@ To Run the Testsuite
 First Steps
 ------------
 * Install dependencies (on debian if using virtualenvwrapper):
-  ``apt-get install virtualenvwrapper python-gi gir1.2-gtk-3.0 libglib2.0-dev libgtk-3-dev``.
+  ``apt-get install virtualenvwrapper python-gi gir1.2-gtk-3.0 libglib2.0-dev
+  libgtk-3-dev``.
   If you use python 3, you will need ``python3-gi`` instead.
 * Create new virtual env: ``mkvirtualenv hamster-gtk``
 * Activate env: ``workon hamster-gtk``
-* Activate system site dirs: ``toggleglobalsitepackages``. Otherwise you will have no access
-  to Gtk.
+* Activate system site dirs: ``toggleglobalsitepackages``. Otherwise you will
+  have no access to Gtk.
 * Install ``hamster-gtk``: ``pip install hamster-gtk``.
 * Run the little furball: ``hamster-gtk``
 
 Some notes:
+
 * Preference changes will only be applied at the next start right now.
 * Exported data is tab seperated.
 * This is pre-alpha software!
 
 News: Version 0.11.0
 ----------------------
-This release introduces refines various aspects of your *Hamster-GTK* experience.
-Whilst we introduce no new major dialogs (just a simple about-dialog). We
-catch up with the lastest version of ``hamster-lib``, ``0.12.0``. The most
-noteworthy change for user is probably the ability to use whitespaces with your
-``Activity.name``. Besides that we fixed some rather anoying bugs as well as
-continued to refine the codebase. All in all, while still not big on features,
-this release should feel much more stable and reliable. This is not the least
-due to multiple contributions by ``jtojnar``, thanks for that!
-As ususal, for more changes and details, please refer to the changelog.
-Happy tracking; Eric.
-`
+This release introduces refines various aspects of your *Hamster-GTK*
+experience. Whilst we introduce no new major dialogs (just a simple
+about-dialog). We catch up with the lastest version of ``hamster-lib``,
+``0.12.0``. The most noteworthy change for user is probably the ability to use
+whitespaces with your ``Activity.name``. Besides that we fixed some rather
+anoying bugs as well as continued to refine the codebase. All in all, while
+still not big on features, this release should feel much more stable and
+reliable. This is not the least due to multiple contributions by ``jtojnar``,
+thanks for that! As ususal, for more changes and details, please refer to the
+changelog. Happy tracking; Eric.


### PR DESCRIPTION
Re-wrap documentation so that lines are shorter than 80 characters.

Closes: #132 
