### PR TITLE
Clean up Travis-Tox interation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ language: python
 python:
     - "2.7"
 
+env:
+  - TOXENV=flake8
+  - TOXENV=pep257
+  - TOXENV=manifest
+  - TOXENV=docs
+
 cache: pip
 
 addons:
@@ -28,8 +34,7 @@ addons:
 virtualenv:
   system_site_packages: true
 
-before_install:
-    #- pip install codecov
+install:
   - pip install --upgrade pip
   - pip install -r requirements/test.pip
   - sudo apt-get install --only-upgrade libgtk-3-dev
@@ -38,7 +43,6 @@ before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3 # give xvfb some time to start
-# command to run tests, e.g. python setup.py test
+
 script:
     - tox
-#- py.test --verbose tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, pep257, manifest
+envlist = flake8, pep257, manifest, py27, py35
 
 [testenv]
 sitepackages=True


### PR DESCRIPTION
Whilst we still not manage to run our proper py.test tests on Travis-CI
this commit makes sure that the rest of our setup is clean and well
structured. For this purpose our default tox call will now run the
entire test suite (this is what you do locally) whilst Travis-CI uses
`TOXENV` variable to determine which environments are run. An for the
time being this includes only our 'linter' test environments.
