### PR TITLE
Implement autocomplete for 'start tracking'

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -37,12 +37,12 @@ import hamster_lib
 from backports.configparser import SafeConfigParser
 from gi.repository import Gdk, GObject, Gtk
 from hamster_lib.helpers import config_helpers
-from hamster_gtk.helpers import get_parent_window, get_resource_path
 from six import text_type
 
 # [FIXME]
 # Remove once hamster-lib has been patched
-from hamster_gtk.helpers import get_config_instance
+from hamster_gtk.helpers import (get_config_instance, get_parent_window,
+                                 get_resource_path)
 from hamster_gtk.misc import HamsterAboutDialog as AboutDialog
 from hamster_gtk.overview import OverviewDialog
 from hamster_gtk.preferences import PreferencesDialog
@@ -143,7 +143,7 @@ class MainWindow(Gtk.ApplicationWindow):
         )
 
         # Set tracking as default screen at startup.
-        self.add(TrackingScreen(self.app))
+        self.add(TrackingScreen(self.app.controller))
 
 
 # [FIXME]

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -19,10 +19,13 @@
 
 """General purpose helper methods."""
 
+from __future__ import absolute_import, unicode_literals
+
 import datetime
+import os.path
 
 import six
-import os.path
+from six import text_type
 
 
 def _u(string):
@@ -117,7 +120,7 @@ def calendar_date_to_datetime(date):
 
 # [FIXME]
 # Remove once hamster-lib is patched
-# This should probablyy be named/limited to: 'read_config_file'.
+# This should probably be named/limited to: 'read_config_file'.
 # The 'fallback' behaviour should live with ``_get_config_from_file``.
 def get_config_instance(fallback_config_instance, app_name, file_name):
     """Patched version of ``hamster-lib`` helper function until it get fixed upstream."""
@@ -135,3 +138,39 @@ def get_config_instance(fallback_config_instance, app_name, file_name):
 def get_resource_path(file_name):
     """Return path to a resource file."""
     return os.path.join(os.path.dirname(__file__), 'resources', file_name)
+
+
+def serialise_activity(activity):
+    """Provide a serialised activity string representation."""
+    if activity.category:
+        activity_string = '{a.name}@{a.category.name}'.format(a=activity)
+    else:
+        activity_string = activity.name
+    return text_type(activity_string)
+
+
+def serialise_fact(fact):
+    """Provide a serialised fact string representation."""
+    # [FIXME] This should be obsolete once LIB-216 is implemented.
+    start_string = ''
+    if fact.start:
+        start_string = fact.start.strftime('%Y-%m-%d %H:%M')
+
+    end_string = ''
+    if fact.end:
+        end_string = ' - ' + fact.end.strftime("%Y-%m-%d %H:%M")
+
+    timestring = start_string + end_string
+    if timestring:
+        timestring += ' '
+
+    category_string = ''
+    if fact.activity.category:
+        category_string = '@{}'.format(fact.activity.category.name)
+
+    label = '{time}{activity}{category}'.format(
+        time=timestring,
+        activity=text_type(fact.activity.name),
+        category=text_type(category_string)
+    )
+    return text_type(label)

--- a/hamster_gtk/misc/dialogs/__init__.py
+++ b/hamster_gtk/misc/dialogs/__init__.py
@@ -19,7 +19,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from .hamster_about_dialog import HamsterAboutDialog  # NOQA
 from .date_range_select_dialog import DateRangeSelectDialog  # NOQA
 from .edit_fact_dialog import EditFactDialog  # NOQA
 from .error_dialog import ErrorDialog  # NOQA
+from .hamster_about_dialog import HamsterAboutDialog  # NOQA

--- a/hamster_gtk/misc/dialogs/edit_fact_dialog.py
+++ b/hamster_gtk/misc/dialogs/edit_fact_dialog.py
@@ -26,7 +26,7 @@ from gi.repository import Gtk
 from hamster_lib import Fact
 from six import text_type
 
-from hamster_gtk.helpers import _u
+from hamster_gtk.helpers import _u, serialise_fact
 
 
 class EditFactDialog(Gtk.Dialog):
@@ -119,23 +119,8 @@ class EditFactDialog(Gtk.Dialog):
         # [FIXME]
         # Maybe it would be sensible to have a serialization helper method as
         # part of ``hamster-lib``?!
-        start_string = self._fact.start.strftime('%Y-%m-%d %H:%M')
-        end_string = self._fact.end.strftime("%Y-%m-%d %H:%M")
-        if self._fact.category is None:
-            label = '{start} - {end} {activity}'.format(
-                start=start_string,
-                end=end_string,
-                activity=text_type(self._fact.activity.name)
-            )
-        else:
-            label = '{start} - {end} {activity}@{category}'.format(
-                start=start_string,
-                end=end_string,
-                activity=text_type(self._fact.activity.name),
-                category=text_type(self._fact.category.name)
-            )
 
-        entry.set_text(label)
+        entry.set_text(serialise_fact(self._fact))
         entry.set_name('EditDialogRawFactEntry')
         return entry
 

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -1,0 +1,127 @@
+# -*- encoding: utf-8 -*-
+
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Widget meant to handle 'raw-fact' strings and provides autocompletion."""
+from __future__ import absolute_import, unicode_literals
+import datetime
+
+from gi.repository import GObject, Gtk
+from orderedset import OrderedSet
+from six import text_type
+from hamster_lib import Category, Fact
+from hamster_gtk.helpers import _u
+from hamster_gtk import helpers
+
+
+class RawFactEntry(Gtk.Entry):
+    """A custom entry widgets that provides ``faw fact`` specific autocompletion behaviour."""
+
+    def __init__(self, controller, *args, **kwargs):
+        """Instantiate the class."""
+        super(RawFactEntry, self).__init__(*args, **kwargs)
+        self._controller = controller
+        self._controller.signal_handler.connect('facts-changed', self._on_facts_changed)
+        self.set_completion(RawFactCompletion(self._controller))
+
+    # Callbacks
+    def _on_facts_changed(self, evtl):
+        """Callback triggered when facts have changed."""
+        self.set_completion(RawFactCompletion(self._controller))
+
+
+class RawFactCompletion(Gtk.EntryCompletion):
+    """
+    Return a completion instance to match 'activity@category' strings.
+
+    Returns:
+        Gtk.EntryCompletion: Completion instance.
+    """
+
+    def __init__(self, controller, *args, **kwargs):
+        """instantiate class."""
+        super(RawFactCompletion, self).__init__(*args, **kwargs)
+        self._controller = controller
+        self.set_model(self._get_store())
+        self.set_text_column(0)
+        self.set_match_func(self._match_anywhere, None)
+        self.connect('match-selected', self._on_match_selected)
+
+    def _get_store(self):
+        store = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING)
+        for activity in self._get_activities():
+            category = ''
+            if activity.category:
+                category = text_type(activity.category.name)
+            store.append([
+                helpers.serialise_activity(activity), text_type(activity.name), category
+            ])
+        return store
+
+    def _get_activities(self):
+        today = datetime.date.today()
+        recent_activities = [fact.activity for fact in self._controller.facts.get_all(
+            start=today, end=today)]
+        return OrderedSet(recent_activities)
+
+    def _match_anywhere(self, entrystr, iter, data, *args):
+        """
+        Check if the entrysring is a substring of our text_column.
+
+        Args:
+            entrystr (str): The text extracted from the entry so far. Note that key is
+                normalized and case-folded (see GLib.utf8_normalize() and
+                GLib.utf8_casefold()).
+            iter: Iterator position indicating the model row we check against.
+            data: Arbitrary user data.
+
+        Returns:
+            boot: ``True`` if ``entrystring`` is a substring, ``False`` if not.
+
+        Note this is a custom match function, for details on the general generic
+        solution [please see|https://lazka.github.io/pgi-docs/#Gtk-3.0/
+        callbacks.html#Gtk.EntryCompletionMatchFunc].
+        """
+        # 'activity@category' string that we try to match against.
+        modelstr = _u(self.get_model()[iter][0])
+        # Parse the entire entry string to extract all semantic information.
+        fact = Fact.create_from_raw_fact(_u(entrystr))
+        # Make the extracted ``Fact`` available to other callbacks.
+        self._tmp_fact = fact
+        # If the parsed string seems to contain any activity related
+        # information, encode it in its canonical form.
+        if fact.activity:
+            activity_string = helpers.serialise_activity(fact.activity)
+        return activity_string in modelstr
+
+    def _on_match_selected(self, model, iter):
+        """Callback to be executed once a match is selected by the user."""
+        activity_name = _u(model[iter][1])
+        category_name = _u(model[iter][2])
+        fact = self._tmp_fact
+        # We complete ``self._tmp_fact`` with activity/category information
+        # taken from the matching model row.
+        fact.activity.name = activity_name
+        if category_name:
+            fact.activity.category = Category(category_name)
+        else:
+            fact.activity.category = None
+        # Put a string that contains all available and completed information
+        # in the text entry.
+        self.get_entry().set_text(helpers.serialise_fact(fact))
+        self.get_entry().set_position(-1)
+        return True

--- a/hamster_gtk/preferences/widgets/combo_file_chooser.py
+++ b/hamster_gtk/preferences/widgets/combo_file_chooser.py
@@ -27,11 +27,9 @@ from gettext import gettext as _
 from gi.repository import Gtk
 from six import text_type
 
-from hamster_gtk.helpers import get_parent_window
-
 # [FIXME]
 # Remove once hamster-lib has been patched
-from hamster_gtk.helpers import _u
+from hamster_gtk.helpers import _u, get_parent_window
 
 from .config_widget import ConfigWidget
 

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -28,6 +28,7 @@ from gettext import gettext as _
 from gi.repository import GObject, Gtk
 from hamster_lib import Fact
 
+from hamster_gtk.misc.widgets import RawFactEntry
 import hamster_gtk.helpers as helpers
 from hamster_gtk.helpers import _u
 
@@ -35,17 +36,17 @@ from hamster_gtk.helpers import _u
 class TrackingScreen(Gtk.Stack):
     """Main container for the tracking screen."""
 
-    def __init__(self, app, *args, **kwargs):
+    def __init__(self, controller, *args, **kwargs):
         """Setup widget."""
-        super(TrackingScreen, self).__init__()
-        self.app = app
+        super(TrackingScreen, self).__init__(*args, **kwargs)
+        self._controller = controller
 
         self.main_window = helpers.get_parent_window(self)
         self.set_transition_type(Gtk.StackTransitionType.SLIDE_UP)
         self.set_transition_duration(1000)
-        self.current_fact_view = CurrentFactBox(self.app.controller)
+        self.current_fact_view = CurrentFactBox(self._controller)
         self.current_fact_view.connect('tracking-stopped', self.update)
-        self.start_tracking_view = StartTrackingBox(self.app.controller)
+        self.start_tracking_view = StartTrackingBox(self._controller)
         self.start_tracking_view.connect('tracking-started', self.update)
         self.add_titled(self.start_tracking_view, 'start tracking', _("Start Tracking"))
         self.add_titled(self.current_fact_view, 'ongoing fact', _("Show Ongoing Fact"))
@@ -59,7 +60,7 @@ class TrackingScreen(Gtk.Stack):
         This depends on wether there exists an *ongoing fact* or not.
         """
         try:
-            current_fact = self.app.controller.store.facts.get_tmp_fact()
+            current_fact = self._controller.store.facts.get_tmp_fact()
         except KeyError:
             self.start_tracking_view.show()
             self.set_visible_child(self.start_tracking_view)
@@ -177,7 +178,7 @@ class StartTrackingBox(Gtk.Box):
         self.pack_start(self.current_fact_label, False, False, 0)
 
         # Fact entry field
-        self.raw_fact_entry = Gtk.Entry()
+        self.raw_fact_entry = RawFactEntry(self._controller)
         self.raw_fact_entry.connect('activate', self._on_raw_fact_entry_activate)
         self.pack_start(self.raw_fact_entry, False, False, 0)
 
@@ -229,11 +230,10 @@ class StartTrackingBox(Gtk.Box):
         self.raw_fact_entry.props.text = ''
 
     # Callbacks
+    def _on_start_tracking_button(self, button):
+        """Callback for the 'start tracking' button."""
+        self._start_ongoing_fact()
 
     def _on_raw_fact_entry_activate(self, evt):
         """Callback for when ``enter`` is pressed within the entry."""
-        self._start_ongoing_fact()
-
-    def _on_start_tracking_button(self, button):
-        """Callback for the 'start tracking' button."""
         self._start_ongoing_fact()

--- a/tests/misc/conftest.py
+++ b/tests/misc/conftest.py
@@ -2,13 +2,17 @@
 
 """Fixtures for unittesting the misc submodule."""
 
+from __future__ import absolute_import, unicode_literals
 import datetime
 
 import fauxfactory
 import pytest
+from gi.repository import GObject, Gtk
+from six import text_type
 
 from hamster_gtk import overview
-from hamster_gtk.misc import dialogs
+from hamster_gtk.misc import dialogs, widgets
+from hamster_gtk import helpers
 
 
 @pytest.fixture
@@ -62,3 +66,41 @@ def monthrange_parametrized(request):
 def edit_fact_dialog(request, fact, dummy_window):
     """Return a edit fact dialog for a generic fact."""
     return dialogs.EditFactDialog(dummy_window, fact)
+
+
+@pytest.fixture
+def raw_fact_entry(request, app):
+    """Return a ``RawFactEntry`` instance."""
+    return widgets.RawFactEntry(app.controller)
+
+
+@pytest.fixture
+def raw_fact_completion(request, app):
+    """Return a RawFactCompletion`` instance."""
+    return widgets.raw_fact_entry.RawFactCompletion(app.controller)
+
+
+@pytest.fixture
+def activity_model_static(request):
+    """
+    Return a ``ListStore`` instance with the 'foo@bar' activity as it's only row.
+
+    While this fixture is not too generic and has its activity hard coded it allows
+    for more specific testing as we can know for sure which (sub) string apear and
+    which do not.
+    """
+    model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING)
+    model.append(['foo@bar', 'foo', 'bar'])
+    return model
+
+
+@pytest.fixture
+def activity_model(request, activity):
+    """Returnd a ``ListStore`` instance with a generic ``Activity`` as it's only row."""
+    model = Gtk.ListStore(GObject.TYPE_STRING, GObject.TYPE_STRING, GObject.TYPE_STRING)
+    model.append([
+        helpers.serialise_activity(activity),
+        text_type(activity.name),
+        text_type(activity.category.name)
+    ])
+    return model

--- a/tests/misc/test_widgets.py
+++ b/tests/misc/test_widgets.py
@@ -1,0 +1,105 @@
+# -*- encoding: utf-8 -*-
+
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, unicode_literals
+
+import pytest
+from gi.repository import Gtk
+from orderedset import OrderedSet
+
+from hamster_gtk.misc import widgets
+from hamster_gtk.misc.widgets.raw_fact_entry import RawFactCompletion
+from hamster_gtk.helpers import _u
+import hamster_gtk.helpers as helpers
+
+
+class TestRawFactEntry(object):
+    """Unittests for RawFactEntry."""
+
+    def test_init(self, app):
+        assert widgets.RawFactEntry(app.controller)
+
+    def test__on_facts_changed(self, raw_fact_entry):
+        old_completion = raw_fact_entry.get_completion()
+        raw_fact_entry._on_facts_changed(None)
+        assert raw_fact_entry.get_completion() is not old_completion
+
+
+class TestRawFactCompletion(object):
+    """Unittests for RawFactCompletion."""
+
+    def test_init__(self, app, mocker):
+        """Test instantiation."""
+        result = RawFactCompletion(app.controller)
+        assert result.get_model()
+        assert result.get_text_column() == 0
+
+    def test__get_store(self, raw_fact_completion, activity_factory, mocker):
+        """Make sure the ``ListStore`` is constructed to our expectations."""
+        raw_fact_completion._get_activities = mocker.MagicMock(
+            return_value=activity_factory.build_batch(10))
+        result = raw_fact_completion._get_store()
+        assert isinstance(result, Gtk.ListStore)
+        assert raw_fact_completion._get_activities.called
+        assert len(result) == 10
+
+    def test__get_activities(self, app, raw_fact_completion, fact_factory, mocker):
+        """Make sure that we fetch the right activities and remove duplicates."""
+        # In reality we can not get duplicate facts but separate facts with the
+        # same ``Activity`` but this will do just fine.
+        fact_1, fact_2 = fact_factory.build_batch(2)
+        app.controller.facts.get_all = mocker.MagicMock(
+            return_value=[fact_1, fact_2, fact_1])
+        result = raw_fact_completion._get_activities()
+        assert result == OrderedSet([fact_1.activity, fact_2.activity])
+
+    @pytest.mark.parametrize(('entrystring', 'expectation'), (
+        ('foo', True),
+        ('bar', True),
+        ('fo', True),
+        ('oo', True),
+        ('ar', True),
+        ('ba', True),
+        ('foobar', False),
+    ))
+    def test__match_anywhere(self, raw_fact_completion, activity_model_static, mocker,
+            entrystring, expectation):
+        """Make sure that only valid sub strings return ``True``."""
+        raw_fact_completion.get_model = mocker.MagicMock(return_value=activity_model_static)
+        iter = activity_model_static.get_iter(0)
+        result = raw_fact_completion._match_anywhere(entrystring, iter, None)
+        assert raw_fact_completion._tmp_fact
+        assert result is expectation
+
+    def test__match_selected(self, raw_fact_entry, raw_fact_completion, activity,
+            activity_model, fact):
+        """
+        Make sure that selecting a match completes the entry as expected.
+
+        Besides checking that the entry string we also make sure the cursor is placed
+        just after the text.
+        """
+        iter = activity_model.get_iter(0)
+        raw_fact_entry.set_completion(raw_fact_completion)
+        raw_fact_completion._tmp_fact = fact
+        raw_fact_completion._on_match_selected(activity_model, iter)
+        entry = raw_fact_completion.get_entry()
+        fact.activity = activity
+        serialised_fact = helpers.serialise_fact(fact)
+        assert _u(entry.get_text()) == serialised_fact
+        assert entry.get_position() == len(serialised_fact)

--- a/tests/tracking/conftest.py
+++ b/tests/tracking/conftest.py
@@ -12,7 +12,7 @@ from hamster_gtk.tracking import screens
 @pytest.fixture
 def tracking_screen(request, app):
     """Return a plain TrackingScreen instance."""
-    return screens.TrackingScreen(app)
+    return screens.TrackingScreen(app.controller)
 
 
 @pytest.fixture

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -15,14 +15,14 @@ class TestTrackingScreen(object):
 
     def test_init(self, app):
         """Make sure instance matches expectation."""
-        result = screens.TrackingScreen(app)
+        result = screens.TrackingScreen(app.controller)
         assert isinstance(result, screens.TrackingScreen)
         assert len(result.get_children()) == 2
 
     def test_update_with_ongoing_fact(self, tracking_screen, fact, mocker):
         """Make sure current fact view is shown."""
         fact.end is None
-        tracking_screen.app.controller.store.facts.get_tmp_fact = mocker.MagicMock(
+        tracking_screen._controller.store.facts.get_tmp_fact = mocker.MagicMock(
             return_value=fact)
         tracking_screen.update()
         result = tracking_screen.get_visible_child()
@@ -31,7 +31,7 @@ class TestTrackingScreen(object):
 
     def test_update_with_no_ongoing_fact(self, tracking_screen, mocker):
         """Make sure start tracking view is shown."""
-        tracking_screen.app.controller.store.facts.get_tmp_fact = mocker.MagicMock(
+        tracking_screen._controller.store.facts.get_tmp_fact = mocker.MagicMock(
             side_effect=KeyError)
         tracking_screen.update()
         result = tracking_screen.get_visible_child()


### PR DESCRIPTION
**DO NOT MERGE**

@jtojnar This is my work on autocompletion so far, please have a look if you got a minute and let me know what you think. Once we feel this is the right direction I will try to add some more tests.

This commit adds basic auto completion support to the 'raw_fact entry' of
our ``StartTrackingSreeen``.
For this we make use of ``Gtk.EntryCompletion``. An additional
difficulty is the fact that our raw string may contain 'non completion
relevant' information such as time ranges or descriptions whist the
completion should be limited to ``activity.name``/``activity.category.name``
combinations. By default ``Gtk.EntryCompletion`` substitutes the
entire entry string with the found match. This would mean we loose the
additional information.
- In order to avoid this we first create a 'temporary fact' that contains
all the parsed information present in the entry string so far.
- Then we take any activity/category related information in there to match
against our existing activities.
- Finally we use any matches to feed them back into our 'temporary
fact'.
- If a match was found, a serialized version of the 'tmp fact' gets
placed in the entry field.

Some things are worth noting:
- Due to the fact that we employ ``Fact.create_from_raw_fact`` we apply
our whole 'datetime completion' machinery to the user provided string.
Once the fact gets "written back into the entry" this means the user
provided (potentially partial) information is replaced by the fully
completed datetime information. Whist this was not our original goal it
is actually benefitial as it gives the user clear feedback about what
times will be used. it also fits with the "autocomplete theme".
- For now we provide our own 'serialize fact' helper method. This should
be obsolete once
[LIB-216](https://projecthamster.atlassian.net/browse/LIB-216) has been implemented.