### PR TITLE
Show only develop build status in badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ hamster-gtk
 .. image:: https://img.shields.io/pypi/v/hamster-gtk.svg
         :target: https://pypi.python.org/pypi/hamster-gtk
 
-.. image:: https://img.shields.io/travis/projecthamster/hamster-gtk.svg
+.. image:: https://img.shields.io/travis/projecthamster/hamster-gtk/master.svg
         :target: https://travis-ci.org/projecthamster/hamster-gtk
 
 .. .. image:: https://readthedocs.org/projects/hamster-gtk/badge/?version=latest


### PR DESCRIPTION
Change Travis badge to show the build status of develop branch only. Unless we do this, pushes to WIP branches (e.g. `requires-io-develop`) can make it look like our software is broken.