### PR TITLE
[#147] Allow choosing export type

### DIFF
--- a/hamster_gtk/misc/widgets/__init__.py
+++ b/hamster_gtk/misc/widgets/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*- encoding: utf-8 -*-
 
 # This file is part of 'hamster-gtk'.
 #
@@ -15,10 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module provides widgets to be used by the preferences dialog."""
+"""This module provides several multi purpose widgets."""
 
-from .combo_file_chooser import ComboFileChooser  # NOQA
-from .config_widget import ConfigWidget  # NOQA
-from .hamster_combo_box_text import HamsterComboBoxText  # NOQA
-from .hamster_spin_button import HamsterSpinButton, SimpleAdjustment  # NOQA
-from .time_entry import TimeEntry  # NOQA
+from .labelled_widgets_grid import LabelledWidgetsGrid  # NOQA

--- a/hamster_gtk/misc/widgets/labelled_widgets_grid.py
+++ b/hamster_gtk/misc/widgets/labelled_widgets_grid.py
@@ -15,18 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module provides a Grid for easy construction of preference screens."""
+"""Provides a grid for easy construction of preferences or other displays with similar needs."""
 
 from __future__ import absolute_import
 
 from gi.repository import Gtk
 
 
-class PreferencesGrid(Gtk.Grid):
+class LabelledWidgetsGrid(Gtk.Grid):
     """A widget which arranges labelled fields automatically."""
 
     # Required else you would need to specify the full module name in ui file
-    __gtype_name__ = 'PreferencesGrid'
+    __gtype_name__ = 'LabelledWidgetsGrid'
 
     def __init__(self, fields=None):
         """

--- a/hamster_gtk/overview/dialogs/__init__.py
+++ b/hamster_gtk/overview/dialogs/__init__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides an overview dialog allowing access to all facts, and an export dialog."""
+
+from .export_dialog import ExportDialog  # NOQA
+from .overview_dialog import OverviewDialog, Totals  # NOQA

--- a/hamster_gtk/overview/dialogs/export_dialog.py
+++ b/hamster_gtk/overview/dialogs/export_dialog.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""This Module provides the ``ExportDialog`` class to choose file to be exported."""
+
+from __future__ import absolute_import
+
+import os.path
+from gettext import gettext as _
+
+from gi.repository import Gtk
+
+from hamster_gtk.preferences.widgets import PreferencesGrid
+
+
+class ExportDialog(Gtk.FileChooserDialog):
+    """Dialog used for exporting."""
+
+    def __init__(self, parent):
+        """
+        Initialize export dialog.
+
+        Args:
+            parent (Gtk.Window): Parent window for the dialog.
+        """
+        super(ExportDialog, self).__init__(_("Please choose where to export to"), parent,
+            Gtk.FileChooserAction.SAVE, (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+                                         Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
+
+        self._export_format_chooser = self._get_export_format_chooser()
+        self._export_format_chooser.connect('changed', self._on_export_format_changed)
+
+        export_options = PreferencesGrid(
+            {'format': (_("Export _format:"), self._export_format_chooser)})
+        export_options.show_all()
+        self.set_extra_widget(export_options)
+
+        self.set_current_name(_("hamster_export"))
+        self._export_format_chooser.set_active_id('tsv')
+
+    def _get_export_format_chooser(self):
+        chooser = Gtk.ComboBoxText()
+        chooser.append('tsv', _("TSV"))
+        chooser.append('ical', _("iCal"))
+        chooser.append('xml', _("XML"))
+        return chooser
+
+    def _on_export_format_changed(self, combobox):
+        """
+        Change file extension of the selected file to the one that was chosen.
+
+        Args:
+            combobox (Gtk.ComboBoxText): Combo box that was changed.
+        """
+        new_ext = self.get_export_format()
+        (name, ext) = os.path.splitext(self.get_current_name())
+        self.set_current_name('{}.{}'.format(name, new_ext))
+
+    def get_export_format(self):
+        """
+        Return currently selected export format.
+
+        Returns:
+            text_type: Currently selected export format.
+        """
+        return self._export_format_chooser.get_active_id()

--- a/hamster_gtk/overview/dialogs/export_dialog.py
+++ b/hamster_gtk/overview/dialogs/export_dialog.py
@@ -25,7 +25,7 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 
-from hamster_gtk.preferences.widgets import PreferencesGrid
+from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 
 
 class ExportDialog(Gtk.FileChooserDialog):
@@ -45,7 +45,7 @@ class ExportDialog(Gtk.FileChooserDialog):
         self._export_format_chooser = self._get_export_format_chooser()
         self._export_format_chooser.connect('changed', self._on_export_format_changed)
 
-        export_options = PreferencesGrid(
+        export_options = LabelledWidgetsGrid(
             {'format': (_("Export _format:"), self._export_format_chooser)})
         export_options.show_all()
         self.set_extra_widget(export_options)

--- a/hamster_gtk/overview/dialogs/overview_dialog.py
+++ b/hamster_gtk/overview/dialogs/overview_dialog.py
@@ -37,8 +37,8 @@ from collections import defaultdict, namedtuple
 from gi.repository import GObject, Gtk
 from hamster_lib import reports
 
-from . import widgets
-from .. import helpers
+from .. import widgets
+from ... import helpers
 
 Totals = namedtuple('Totals', ('activity', 'category', 'date'))
 
@@ -245,14 +245,21 @@ class OverviewDialog(Gtk.Dialog):
         offset = (orig_end - orig_start) + datetime.timedelta(days=1)
         self._daterange = (orig_start + offset, orig_end + offset)
 
-    def _export_facts(self, target_path):
+    def _export_facts(self, target_format, target_path):
         """
         Export current set of facts to file.
 
         Args:
+            target_format (text_type): Type of the export.
             target_path (text_type): Location to export to.
         """
-        writer = reports.TSVWriter(target_path)
+        export_writers = {
+            'tsv': reports.TSVWriter,
+            'ical': reports.ICALWriter,
+            'xml': reports.XMLWriter
+        }
+
+        writer = export_writers[target_format](target_path)
         writer.write_report(self._get_facts())
 
     # Widgets

--- a/hamster_gtk/overview/widgets/misc.py
+++ b/hamster_gtk/overview/widgets/misc.py
@@ -26,6 +26,7 @@ from six import text_type
 
 from hamster_gtk.helpers import get_parent_window
 from hamster_gtk.misc.dialogs import DateRangeSelectDialog
+from hamster_gtk.overview.dialogs import ExportDialog
 
 
 class HeaderBar(Gtk.HeaderBar):
@@ -108,14 +109,10 @@ class HeaderBar(Gtk.HeaderBar):
         ``parent._export_facts`` only deals with the actual export.
         """
         parent = get_parent_window(self)
-        dialog = Gtk.FileChooserDialog(_("Please Choose where to export to"), parent,
-            Gtk.FileChooserAction.SAVE, (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
-                                         Gtk.STOCK_SAVE, Gtk.ResponseType.OK))
-        dialog.set_current_name('{}.csv'.format(_("hamster_export")))
+        dialog = ExportDialog(parent)
         response = dialog.run()
         if response == Gtk.ResponseType.OK:
-            target_path = dialog.get_filename()
-            parent._export_facts(target_path)
+            parent._export_facts(dialog.get_export_format(), dialog.get_filename())
         else:
             pass
         dialog.destroy()

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -28,10 +28,10 @@ from gettext import gettext as _
 import hamster_lib
 from gi.repository import GObject, Gtk
 
+from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 from hamster_gtk.preferences.widgets import (ComboFileChooser,
                                              HamsterComboBoxText,
                                              HamsterSpinButton,
-                                             PreferencesGrid,
                                              SimpleAdjustment, TimeEntry)
 
 
@@ -62,12 +62,12 @@ class PreferencesDialog(Gtk.Dialog):
 
         # We use an ordered dict as the order reflects display order as well.
         self._pages = [
-            (_('Tracking'), PreferencesGrid(collections.OrderedDict([
+            (_('Tracking'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('day_start', (_('_Day Start (HH:MM:SS)'), TimeEntry())),
                 ('fact_min_delta', (_('_Minimal Fact Duration'),
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
             ]))),
-            (_('Storage'), PreferencesGrid(collections.OrderedDict([
+            (_('Storage'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('store', (_('_Store'), HamsterComboBoxText(stores))),
                 ('db_engine', (_('DB _Engine'), HamsterComboBoxText(db_engines))),
                 ('db_path', (_('DB _Path'), ComboFileChooser())),

--- a/tests/misc/widgets/__init__.py
+++ b/tests/misc/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Unittests for the miscellaneous widgets."""

--- a/tests/misc/widgets/conftest.py
+++ b/tests/misc/widgets/conftest.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+"""Fixtures for unittesting the misc widgets submodule."""
+
+from __future__ import absolute_import, unicode_literals
+
+import collections
+
+import pytest
+from hamster_gtk.misc import widgets
+from hamster_gtk.preferences.widgets import (ComboFileChooser,
+                                             HamsterComboBoxText)
+
+
+@pytest.fixture
+def preference_page_fields(request):
+    """Return a static dict of valid fields suitable to be consumed by ``LabelledWidgetsGrid``."""
+    return collections.OrderedDict((
+        ('store', ('_Store', HamsterComboBoxText([]))),
+        ('db_engine', ('DB _Engine', HamsterComboBoxText([]))),
+        ('db_path', ('DB _Path', ComboFileChooser())),
+        ('tmpfile_path', ('_Temporary file', ComboFileChooser())),
+    ))
+
+
+@pytest.fixture
+def labelled_widgets_grid(request, preference_page_fields):
+    """Return a ``LabelledWidgetsGrid`` instance."""
+    return widgets.LabelledWidgetsGrid(preference_page_fields)

--- a/tests/misc/widgets/test_labelled_widgets_grid.py
+++ b/tests/misc/widgets/test_labelled_widgets_grid.py
@@ -4,35 +4,35 @@ from __future__ import unicode_literals
 
 import pytest
 
-from hamster_gtk.preferences.widgets import PreferencesGrid
+from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 
 
 @pytest.mark.parametrize('no_fields', (True, False))
 def test_init(preference_page_fields, no_fields):
     """Make sure instantiation works with and without fields provided."""
     if no_fields:
-        grid = PreferencesGrid()
+        grid = LabelledWidgetsGrid()
         assert grid._fields == {}
     else:
-        grid = PreferencesGrid(preference_page_fields)
+        grid = LabelledWidgetsGrid(preference_page_fields)
         assert grid._fields == preference_page_fields
     rows = len(grid.get_children()) / 2
     assert rows == len(grid._fields)
 
 
-def test_get_values(preferences_grid, preference_page_fields, mocker):
+def test_get_values(labelled_widgets_grid, preference_page_fields, mocker):
     """Make sure widget fetches values for all its sub-widgets."""
     for key, (label, widget) in preference_page_fields.items():
         widget.get_config_value = mocker.MagicMock()
-    preferences_grid.get_values()
+    labelled_widgets_grid.get_values()
     for key, (label, widget) in preference_page_fields.items():
         assert widget.get_config_value.called
 
 
-def test_set_values(preferences_grid, preference_page_fields, mocker):
+def test_set_values(labelled_widgets_grid, preference_page_fields, mocker):
     """Make sure widget sets values for all its sub-widgets."""
     for key, (label, widget) in preference_page_fields.items():
         widget.set_config_value = mocker.MagicMock()
-    preferences_grid.set_values(preference_page_fields)
+    labelled_widgets_grid.set_values(preference_page_fields)
     for key, (label, widget) in preference_page_fields.items():
         assert widget.set_config_value.called

--- a/tests/overview/test_dialogs.py
+++ b/tests/overview/test_dialogs.py
@@ -17,7 +17,8 @@ class TestOverviewDialog(object):
     def test__get_facts_handled_exception(self, overview_dialog, exception, mocker):
         """Make sure that we show error dialog if we encounter an expected exception."""
         overview_dialog._app.store.facts.get_all = mocker.MagicMock(side_effect=exception)
-        show_error = mocker.patch('hamster_gtk.overview.dialogs.helpers.show_error')
+        show_error = mocker.patch(
+            'hamster_gtk.overview.dialogs.overview_dialog.helpers.show_error')
         result = overview_dialog._get_facts()
         assert result is None
         assert show_error.called
@@ -31,16 +32,22 @@ class TestOverviewDialog(object):
     # [FIXME]
     # It is probably good to also have a more comprehensive test that actually
     # checks if a file with particular content is written.
-    def test__export_facts(self, overview_dialog, tmpdir, mocker):
+    @pytest.mark.parametrize('format_writer', (
+        ('tsv', 'hamster_gtk.overview.dialogs.overview_dialog.reports.TSVWriter'),
+        ('ical', 'hamster_gtk.overview.dialogs.overview_dialog.reports.ICALWriter'),
+        ('xml', 'hamster_gtk.overview.dialogs.overview_dialog.reports.XMLWriter')
+    ))
+    def test__export_facts(self, overview_dialog, tmpdir, mocker, format_writer):
         """
         Make sure the proper report class is instantiated and writter.
 
         With all its mocks this test is not the best one imageinable, but as
         the method will change rapidly soon this does for now.
         """
-        writer = mocker.patch('hamster_gtk.overview.dialogs.reports.TSVWriter')
+        target_format, writer = format_writer
+        writer = mocker.patch(writer)
         overview_dialog._get_facts = mocker.MagicMock(return_value={})
-        result = overview_dialog._export_facts(tmpdir.strpath)
+        result = overview_dialog._export_facts(target_format, tmpdir.strpath)
         assert result is None
         assert writer.called
         assert overview_dialog._get_facts.called

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -5,13 +5,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import datetime
-import collections
 
 import fauxfactory
 import pytest
 
 from hamster_gtk.preferences.preferences_dialog import PreferencesDialog
-from hamster_gtk.preferences import widgets
 
 
 # Data
@@ -85,25 +83,8 @@ def config_parametrized(request, store_parametrized, day_start_parametrized,
             }
 
 
-@pytest.fixture
-def preference_page_fields(request):
-    """Return a static dict of valid fields suitable to be consumed by ``PreferenceGrid``."""
-    return collections.OrderedDict((
-        ('store', ('_Store', widgets.HamsterComboBoxText([]))),
-        ('db_engine', ('DB _Engine', widgets.HamsterComboBoxText([]))),
-        ('db_path', ('DB _Path', widgets.ComboFileChooser())),
-        ('tmpfile_path', ('_Temporary file', widgets.ComboFileChooser())),
-    ))
-
-
 # Instances
 @pytest.fixture
 def preferences_dialog(request, dummy_window, app, config):
     """Return a ``PreferenceDialog`` instance."""
     return PreferencesDialog(dummy_window, app, config)
-
-
-@pytest.fixture
-def preferences_grid(request, preference_page_fields):
-    """Return a ``PreferenceGrid`` instance."""
-    return widgets.PreferencesGrid(preference_page_fields)


### PR DESCRIPTION
As ``hamster-lib`` already supports multiple export backends, this commit only had to add an interface making it accessible.

Currently, CSV, iCalendar and XML are supported by ``hamster-lib``.

The unit tests will have to be added before merging.

Closes: #145 #147 