### PR TITLE
Feature/Cleanup Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,41 +8,11 @@ language: python
 python:
     - "2.7"
 
-env:
-  - TOXENV=flake8
-  - TOXENV=pep257
-  - TOXENV=manifest
-  - TOXENV=docs
-
 cache: pip
-
-addons:
-  apt:
-    packages:
-    - gir1.2-pango-1.0
-    - gir1.2-gtk-3.0
-    - libglib2.0-dev
-    - libgtk-3-dev
-    - python-gi
-    - python-cairo
-    - python-gi-cairo
-    # - python3-gobject Provided by python3-gi
-    #- python3-gi
-    #- python3-cairo
-    #- python3-gi-cairo
-
-virtualenv:
-  system_site_packages: true
 
 install:
   - pip install --upgrade pip
   - pip install -r requirements/test.pip
-  - sudo apt-get install --only-upgrade libgtk-3-dev
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 
 script:
     - tox

--- a/Makefile
+++ b/Makefile
@@ -67,16 +67,12 @@ lint:
 	flake8 hamster-dbus tests
 
 test:
-	xvfb-run py.test $(TEST_ARGS) tests/
+	py.test $(TEST_ARGS) tests/
 
-test-all:
+test-all: test
 	tox
 
 coverage:
-	xvfb-run coverage run -m pytest $(TEST_ARGS) tests
-	coverage report
-
-coverage-no-xvfb:
 	coverage run -m pytest $(TEST_ARGS) tests
 	coverage report
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,30 @@ Some notes:
 * Exported data is tab seperated.
 * This is pre-alpha software!
 
+How to run the testsuite
+-------------------------
+- Create a virtual environment ``mkvirtualenv hamster-gtk`` (python 2) or
+  ``mkvirtualenv -p python3 hamster-gtk`` (python 3). Whilst those instructions
+  do not reflect best practices (which would make use of python 3's built in
+  venv) it does provide a better handling of ``system-site-packages``.
+  `This issue <http://bugs.python.org/issue24875>`_ provides some context for
+  the problems one may run into using ``system-site-packages`` with python3
+  venvs. It is our hope that python 3.7 will fix this.
+- enable access to system-site-packages for our virtual environment:
+  ``$ toggleglobalsitepackages``. This is needed to access our global GTK
+  related packages.
+- Install development environment: ``make develop``.
+- To run the actual testsuite: ``make test``.
+- To run tests and some auxiliary style checks (flake8, pep257, etc):
+  ``make test-all``.
+
+Right now, our actual code testing does not utilize ``tox`` as we keep running
+into segfaults (which does not happen without ``tox``).
+For  this same reason we are currently unable to run our code tests on Travis
+as well (we still run the 'style checks' at least).
+We hope to get to the bottom of this at some point and would be most grateful
+if you have any hint or pointer that may help tracking down this issue.
+
 News: Version 0.11.0
 ----------------------
 This release introduces refines various aspects of your *Hamster-GTK*

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ First Steps
 Some notes:
 
 * Preference changes will only be applied at the next start right now.
-* Exported data is tab seperated.
+* Exported data is tab separated.
 * This is pre-alpha software!
 
 How to run the testsuite

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -3,14 +3,26 @@
 # This file is not part of our packaging specification. It is used to generate
 # a reproduceable test environment. For check out ``docs/packaging``.
 # For package-requirements refer to ``setup.py``.
+#
+# Some of the requirements are repeated in ``tox.ini`` to explicity check their version.
+# Including them here as well has the advantage of keeping them up to date via requires.io
 
+
+check-manifest==0.35
 coverage==4.3.4
+doc8==0.7.0
 fauxfactory==2.0.9
+flake8==3.2.1
+flake8-debugger==1.4.0
+flake8-print==2.0.2
+freezegun==0.3.8
+future==0.16.0
 isort==4.2.5
+pep8-naming==0.4.1
+pep257==0.7.0
 pytest==3.0.6
 pytest-faker==2.0.0
 pytest-factoryboy==1.3.0
-tox==2.5.0
-future==0.16.0
-freezegun==0.3.8
 pytest-mock==1.5.0
+pytest-xvfb==1.0.0
+tox==2.5.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,8 @@ not_skip = __init__.py
 known_third_party = backports, faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
 	past, pytest, pytest_factoryboy, six
 
-[pytest]
-addopt = 
+[tool:pytest]
+addopt =
 	--tb=short
 	--strict
 	--rsx

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -38,8 +38,9 @@ def fact_min_delta_parametrized(request):
 
 
 @pytest.fixture(params=(
-    fauxfactory.gen_utf8(),
-    fauxfactory.gen_latin1(),
+    # fauxfactory.gen_utf8(),
+    # fauxfactory.gen_latin1(),
+    fauxfactory.gen_alphanumeric(),
 ))
 def tmpfile_path_parametrized(request, tmpdir):
     """Return a parametrized tmpfile_path value."""
@@ -55,8 +56,9 @@ def db_engine_parametrized(request):
 
 
 @pytest.fixture(params=(
-    fauxfactory.gen_utf8(),
-    fauxfactory.gen_latin1(),
+    # fauxfactory.gen_utf8(),
+    # fauxfactory.gen_latin1(),
+    fauxfactory.gen_alphanumeric(),
     ':memory:',
 ))
 def db_path_parametrized(request, tmpdir):

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,25 @@
 [tox]
-envlist = flake8, pep257, manifest, py27, py35
+# We skip isort because it conflicts with setting GTK version in inports
+# https://github.com/timothycrosley/isort/issues/295
+envlist = docs, flake8, manifest, pep257
 
 [testenv]
-sitepackages=True
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_gtk
 whitelist_externals =
     make
-    xvfb-run
 passenv =
     SPHINXOPTS_BUILD
     SPHINXOPTS_LINKCHECK
+
+[testenv:docs]
+basepython = python3
+deps = doc8==0.7.0
 commands =
-	pip install -r requirements/dev.pip
-	xvfb-run make coverage-no-xvfb
+    pip install -r requirements/docs.pip
+    make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}
+    make --directory=docs linkcheck BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_LINKCHECK:}
+    doc8
 
 [testenv:flake8]
 basepython = python3
@@ -25,20 +31,6 @@ deps =
 skip_install = True
 commands = flake8 setup.py hamster_gtk/ tests/
 
-[testenv:pep257]
-basepython = python3
-skip_install = True
-deps =
-    pep257==0.7.0
-commands =
-    pep257 setup.py hamster_gtk/ tests/
-
-[testenv:isort]
-basepython = python3
-deps = isort==4.2.5
-skip_install = True
-commands =
-    isort --check-only --recursive --verbose setup.py hamster_gtk/ tests/
 [testenv:manifest]
 basepython = python3
 deps = check-manifest==0.35
@@ -46,11 +38,10 @@ skip_install = True
 commands =
     check-manifest -v
 
-[testenv:docs]
+[testenv:pep257]
 basepython = python3
-deps = doc8==0.7.0
+skip_install = True
+deps =
+    pep257==0.7.0
 commands =
-    pip install -r requirements/docs.pip
-    make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}
-    make --directory=docs linkcheck BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_LINKCHECK:}
-    doc8
+    pep257 setup.py hamster_gtk/ tests/


### PR DESCRIPTION
This PR changes our testsuite to reflect and work around our ongoing difficulties.
Whilst we are able to run ``py.test`` within a regular virtualenv setup (with the help of ``xvfb``) we consistently end up with a segfault doing the same in a tox setting or on the travis CI server.

This PR changes our make target to run just ``py.test`` for the actual code tests.
We still make use of ``tox`` for linters and style checks (which also are still run on the CI server). This is a bit overkill but makes sure we still have the infrastructure in place.

Closes: #24 