### PR TITLE
Reenable autodocs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,21 @@ language: python
 python:
     - "2.7"
 
+# Even if we do not run our real code testsuite sphinx autodocs need access to GTK
+addons:
+  apt:
+    packages:
+    - gir1.2-pango-1.0
+    - gir1.2-gtk-3.0
+    - libglib2.0-dev
+    - libgtk-3-dev
+    - python-gi
+    - python-cairo
+    - python-gi-cairo
+
+virtualenv:
+  system_site_packages: true
+
 cache: pip
 
 install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,8 @@ import hamster_gtk
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    #'sphinx.ext.autodoc',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',

--- a/tox.ini
+++ b/tox.ini
@@ -8,18 +8,21 @@ setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_gtk
 whitelist_externals =
     make
+    xvfb-run
 passenv =
     SPHINXOPTS_BUILD
     SPHINXOPTS_LINKCHECK
 
 [testenv:docs]
-basepython = python3
+basepython = python2
+# We need access to GTK for autodocs
+sitepackages = True
 deps = doc8==0.7.0
 commands =
     pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}
     make --directory=docs linkcheck BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_LINKCHECK:}
-    doc8
+    xvfb-run doc8
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
We avoid issues with importing ``gi`` on the CI server by runing our
``docs`` testenv under python2.

Although we did not make use of the corresponding PR, @jtojnar 's contributions and [efforts tracking down the root cause](https://github.com/projecthamster/hamster-gtk/pull/128/) was instrumental to resolving this.

Closes: #25