### PR TITLE
[#149] Fix test_params_constructor_overlapping_bounds sometimes failing

### DIFF
--- a/tests/preferences/widgets/conftest.py
+++ b/tests/preferences/widgets/conftest.py
@@ -72,9 +72,11 @@ def adjustment(request, numbers):
 
 @pytest.fixture
 def simple_adjustment(request, faker):
-    """Return three random numbers in an ascending order."""
+    """Return a ``SimpleAdjustment``."""
     a = faker.random_number()
     b = faker.random_number()
+    if a == b:
+        b += 1
     step = faker.random_number(digits=2)
     return widgets.SimpleAdjustment(min=min(a, b), max=max(a, b), step=step)
 

--- a/tests/preferences/widgets/conftest.py
+++ b/tests/preferences/widgets/conftest.py
@@ -75,6 +75,8 @@ def simple_adjustment(request, faker):
     """Return three random numbers in an ascending order."""
     a = faker.random_number()
     b = faker.random_number()
+    if a == b:
+        b += 1
     step = faker.random_number(digits=2)
     return widgets.SimpleAdjustment(min=min(a, b), max=max(a, b), step=step)
 


### PR DESCRIPTION
The test swaps upper and lower bounds on the SimpleAdjustment it receives and then expects the HamsterSpinButton to raise. Sometimes, however, the same bounds would be generated and the button would fail to raise.

This commit ensures the generated adjustment never has the same bounds.

Closes: #149