### PR TITLE
[#168] Make activities to be matched by autocomplete configurable 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ A GTK interface to the hamster time tracker.
 **IMPORTANT**
 At this early stage ``hamster-gtk`` is pre-alpha software. As such you are very
 welcome to take it our for a spin and submit feedback, however you should not
-rely on it to work properly and most certainly you should not use it in an
+rely on it to work properly and most certainly you should not use it in a
 production environment!
 You have been warned.
 

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -35,7 +35,7 @@ import hamster_lib
 # under python 2 is practically non existing and manual encoding is not easily
 # possible.
 from backports.configparser import SafeConfigParser
-from gi.repository import Gio, Gdk, GObject, Gtk
+from gi.repository import Gdk, Gio, GObject, Gtk
 from hamster_lib.helpers import config_helpers
 from six import text_type
 

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -104,7 +104,7 @@ class MainWindow(Gtk.ApplicationWindow):
         )
 
         # Set tracking as default screen at startup.
-        self.add(TrackingScreen(self.app.controller, app.config))
+        self.add(TrackingScreen(self.app))
 
 
 # [FIXME]

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -104,7 +104,7 @@ class MainWindow(Gtk.ApplicationWindow):
         )
 
         # Set tracking as default screen at startup.
-        self.add(TrackingScreen(self.app.controller))
+        self.add(TrackingScreen(self.app.controller, app.config))
 
 
 # [FIXME]

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -144,6 +144,7 @@ class HamsterGTK(Gtk.Application):
         # Yes this is redundent, but more transparent. And we can worry about
         # this unwarrented assignment once it actually matters.
         self._config = self._reload_config()
+        self.config = self._config
 
         self._create_actions()
 

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -276,6 +276,8 @@ class HamsterGTK(Gtk.Application):
             'tmpfile_path': os.path.join(appdirs.user_data_dir, 'hamster-gtk.tmp'),
             'db_engine': 'sqlite',
             'db_path': os.path.join(appdirs.user_data_dir, 'hamster-gtk.sqlite'),
+            # Frontend
+            'autocomplete_activities_offset': 30,
         }
 
     def _config_to_configparser(self, config):
@@ -306,6 +308,9 @@ class HamsterGTK(Gtk.Application):
         def get_db_path():
             return text_type(config['db_path'])
 
+        def get_autocomplete_activities_offset():
+            return text_type(config['autocomplete_activities_offset'])
+
         cp_instance = SafeConfigParser()
         cp_instance.add_section('Backend')
         cp_instance.set('Backend', 'store', get_store())
@@ -314,6 +319,10 @@ class HamsterGTK(Gtk.Application):
         cp_instance.set('Backend', 'tmpfile_path', get_tmpfile_path())
         cp_instance.set('Backend', 'db_engine', get_db_engine())
         cp_instance.set('Backend', 'db_path', get_db_path())
+
+        cp_instance.add_section('Frontend')
+        cp_instance.set('Frontend', 'autocomplete_activities_offset',
+                        get_autocomplete_activities_offset())
 
         return cp_instance
 
@@ -364,11 +373,15 @@ class HamsterGTK(Gtk.Application):
                 })
             return result
 
+        def get_autocomplete_activities_offset():
+            return cp_instance.getint('Frontend', 'autocomplete_activities_offset')
+
         result = {
             'store': get_store(),
             'day_start': get_day_start(),
             'fact_min_delta': get_fact_min_delta(),
             'tmpfile_path': get_tmpfile_path(),
+            'autocomplete_activities_offset': get_autocomplete_activities_offset(),
         }
         result.update(get_db_config())
         return result

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -278,6 +278,7 @@ class HamsterGTK(Gtk.Application):
             'db_path': os.path.join(appdirs.user_data_dir, 'hamster-gtk.sqlite'),
             # Frontend
             'autocomplete_activities_offset': 30,
+            'autocomplete_split_activity': False,
         }
 
     def _config_to_configparser(self, config):
@@ -311,6 +312,9 @@ class HamsterGTK(Gtk.Application):
         def get_autocomplete_activities_offset():
             return text_type(config['autocomplete_activities_offset'])
 
+        def get_autocomplete_split_activity():
+            return text_type(config['autocomplete_split_activity'])
+
         cp_instance = SafeConfigParser()
         cp_instance.add_section('Backend')
         cp_instance.set('Backend', 'store', get_store())
@@ -323,6 +327,8 @@ class HamsterGTK(Gtk.Application):
         cp_instance.add_section('Frontend')
         cp_instance.set('Frontend', 'autocomplete_activities_offset',
                         get_autocomplete_activities_offset())
+        cp_instance.set('Frontend', 'autocomplete_split_activity',
+                        get_autocomplete_split_activity())
 
         return cp_instance
 
@@ -376,12 +382,16 @@ class HamsterGTK(Gtk.Application):
         def get_autocomplete_activities_offset():
             return cp_instance.getint('Frontend', 'autocomplete_activities_offset')
 
+        def get_autocomplete_split_activity():
+            return cp_instance.getboolean('Frontend', 'autocomplete_split_activity')
+
         result = {
             'store': get_store(),
             'day_start': get_day_start(),
             'fact_min_delta': get_fact_min_delta(),
             'tmpfile_path': get_tmpfile_path(),
             'autocomplete_activities_offset': get_autocomplete_activities_offset(),
+            'autocomplete_split_activity': get_autocomplete_split_activity(),
         }
         result.update(get_db_config())
         return result

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -277,7 +277,7 @@ class HamsterGTK(Gtk.Application):
             'db_engine': 'sqlite',
             'db_path': os.path.join(appdirs.user_data_dir, 'hamster-gtk.sqlite'),
             # Frontend
-            'autocomplete_activities_offset': 30,
+            'autocomplete_activities_range': 30,
             'autocomplete_split_activity': False,
         }
 
@@ -309,8 +309,8 @@ class HamsterGTK(Gtk.Application):
         def get_db_path():
             return text_type(config['db_path'])
 
-        def get_autocomplete_activities_offset():
-            return text_type(config['autocomplete_activities_offset'])
+        def get_autocomplete_activities_range():
+            return text_type(config['autocomplete_activities_range'])
 
         def get_autocomplete_split_activity():
             return text_type(config['autocomplete_split_activity'])
@@ -325,8 +325,8 @@ class HamsterGTK(Gtk.Application):
         cp_instance.set('Backend', 'db_path', get_db_path())
 
         cp_instance.add_section('Frontend')
-        cp_instance.set('Frontend', 'autocomplete_activities_offset',
-                        get_autocomplete_activities_offset())
+        cp_instance.set('Frontend', 'autocomplete_activities_range',
+                        get_autocomplete_activities_range())
         cp_instance.set('Frontend', 'autocomplete_split_activity',
                         get_autocomplete_split_activity())
 
@@ -379,8 +379,8 @@ class HamsterGTK(Gtk.Application):
                 })
             return result
 
-        def get_autocomplete_activities_offset():
-            return cp_instance.getint('Frontend', 'autocomplete_activities_offset')
+        def get_autocomplete_activities_range():
+            return cp_instance.getint('Frontend', 'autocomplete_activities_range')
 
         def get_autocomplete_split_activity():
             return cp_instance.getboolean('Frontend', 'autocomplete_split_activity')
@@ -390,7 +390,7 @@ class HamsterGTK(Gtk.Application):
             'day_start': get_day_start(),
             'fact_min_delta': get_fact_min_delta(),
             'tmpfile_path': get_tmpfile_path(),
-            'autocomplete_activities_offset': get_autocomplete_activities_offset(),
+            'autocomplete_activities_range': get_autocomplete_activities_range(),
             'autocomplete_split_activity': get_autocomplete_split_activity(),
         }
         result.update(get_db_config())

--- a/hamster_gtk/misc/widgets/__init__.py
+++ b/hamster_gtk/misc/widgets/__init__.py
@@ -17,5 +17,5 @@
 
 """This module provides several multi purpose widgets."""
 
-from .raw_fact_entry import RawFactEntry  # NOQA
 from .labelled_widgets_grid import LabelledWidgetsGrid  # NOQA
+from .raw_fact_entry import RawFactEntry  # NOQA

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -268,8 +268,9 @@ class RawFactCompletion(Gtk.EntryCompletion):
         for autocomplete suggestions.
         """
         today = datetime.date.today()
+        start = today - datetime.timedelta(self._config['autocomplete_activities_offset'])
         recent_activities = [fact.activity for fact in self._controller.facts.get_all(
-            start=today, end=today)]
+            start=start, end=today)]
         return OrderedSet(recent_activities)
 
     def _match_anywhere(self, completion, entrystr, iter, data):

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -60,12 +60,13 @@ def _get_segment_boundaries(segment, match):
 class RawFactEntry(Gtk.Entry):
     """A custom entry widgets that provides ``raw fact`` specific autocompletion behaviour."""
 
-    def __init__(self, controller, split_activity_autocomplete=False, *args, **kwargs):
+    def __init__(self, controller, config, split_activity_autocomplete=False, *args, **kwargs):
         """
         Instantiate class.
 
         Args:
             controller: Controller instance.
+            config: Config instance.
             split_activity_autocomplete (bool, optional): If ``True`` autocompletion
                 will handle ``Activity.name`` and ``Activity.category`` independently.
                 If ``False`` it will try to match against the concatenated ``name@category``
@@ -73,9 +74,10 @@ class RawFactEntry(Gtk.Entry):
         """
         super(RawFactEntry, self).__init__(*args, **kwargs)
         self._controller = controller
+        self._config = config
         self._controller.signal_handler.connect('facts-changed', self._on_facts_changed)
         self._split_activity_autocomplete = split_activity_autocomplete
-        self.set_completion(RawFactCompletion(self._controller))
+        self.set_completion(RawFactCompletion(self._controller, self._config))
         # The re.match instance of the current string or None
         self.match = None
         # Identifier for the segment the cursor is currently in. None if no
@@ -156,7 +158,7 @@ class RawFactEntry(Gtk.Entry):
     # Callbacks
     def _on_facts_changed(self, evt):
         """Callback triggered when facts have changed."""
-        self.set_completion(RawFactCompletion(self._controller))
+        self.set_completion(RawFactCompletion(self._controller, self._config))
 
     def _on_changed(self, widget):
         """
@@ -212,10 +214,11 @@ class RawFactCompletion(Gtk.EntryCompletion):
         Gtk.EntryCompletion: Completion instance.
     """
 
-    def __init__(self, controller, *args, **kwargs):
+    def __init__(self, controller, config, *args, **kwargs):
         """Instantiate class."""
         super(RawFactCompletion, self).__init__(*args, **kwargs)
         self._controller = controller
+        self._config = config
         self._activities_model, self._categories_model, self._activities_with_categories_model = (
             self._get_stores()
         )

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -217,9 +217,10 @@ class RawFactCompletion(Gtk.EntryCompletion):
         """Instantiate class."""
         super(RawFactCompletion, self).__init__(*args, **kwargs)
         self._app = app
-        self._activities_model, self._categories_model, self._activities_with_categories_model = (
-            self._get_stores()
-        )
+        self._activities_model = Gtk.ListStore(GObject.TYPE_STRING)
+        self._categories_model = Gtk.ListStore(GObject.TYPE_STRING)
+        self._activities_with_categories_model = Gtk.ListStore(GObject.TYPE_STRING)
+        self._populare_stores(None)
         self.set_model(self._activities_model)
         self.set_text_column(0)
         self.set_match_func(self._match_anywhere, None)
@@ -230,10 +231,9 @@ class RawFactCompletion(Gtk.EntryCompletion):
             'activity+category': self._activities_with_categories_model,
         }
 
-    def _get_stores(self):
+    def _populate_stores(self, evt):
         activities, categories = OrderedSet(), OrderedSet()
 
-        activities_with_categories_store = Gtk.ListStore(GObject.TYPE_STRING)
         for activity in self._get_activities():
             activities.add(text_type(activity.name))
             if activity.category:
@@ -247,16 +247,16 @@ class RawFactCompletion(Gtk.EntryCompletion):
                 )
             else:
                 text = activity.name
-            activities_with_categories_store.append([text])
+            self._activities_with_categories_model.clear()
+            self._activities_with_categories_model.append([text])
 
-        activities_store = Gtk.ListStore(GObject.TYPE_STRING)
+        self._activities_model.clear()
         for activity in activities:
-            activities_store.append([activity])
+            self._activities_model.append([activity])
 
-        categories_store = Gtk.ListStore(GObject.TYPE_STRING)
+        self._categories_model.clear()
         for category in categories:
-            categories_store.append([category])
-        return (activities_store, categories_store, activities_with_categories_store)
+            self._categories_model.append([category])
 
     def _get_activities(self):
         """

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -272,7 +272,7 @@ class RawFactCompletion(Gtk.EntryCompletion):
         for autocomplete suggestions.
         """
         today = datetime.date.today()
-        offset = self._app._config['autocomplete_activities_offset']
+        offset = self._app._config['autocomplete_activities_range']
         start = today - datetime.timedelta(days=offset)
         recent_activities = [fact.activity for fact in self._app.controller.facts.get_all(
             start=start, end=today)]

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -22,11 +22,11 @@ from __future__ import absolute_import, unicode_literals
 import datetime
 
 from gi.repository import GObject, Gtk
+from orderedset import OrderedSet
 from six import text_type
 
 from hamster_gtk import helpers
 from hamster_gtk.helpers import _u
-from orderedset import OrderedSet
 
 
 def _get_segment_boundaries(segment, match):

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -60,7 +60,7 @@ def _get_segment_boundaries(segment, match):
 class RawFactEntry(Gtk.Entry):
     """A custom entry widgets that provides ``raw fact`` specific autocompletion behaviour."""
 
-    def __init__(self, controller, config, split_activity_autocomplete=False, *args, **kwargs):
+    def __init__(self, app, split_activity_autocomplete=False, *args, **kwargs):
         """
         Instantiate class.
 
@@ -73,11 +73,10 @@ class RawFactEntry(Gtk.Entry):
                 string. Defaults to ``False``.
         """
         super(RawFactEntry, self).__init__(*args, **kwargs)
-        self._controller = controller
-        self._config = config
-        self._controller.signal_handler.connect('facts-changed', self._on_facts_changed)
+        self._app = app
+        self._app.controller.signal_handler.connect('facts-changed', self._on_facts_changed)
         self._split_activity_autocomplete = split_activity_autocomplete
-        self.set_completion(RawFactCompletion(self._controller, self._config))
+        self.set_completion(RawFactCompletion(app))
         # The re.match instance of the current string or None
         self.match = None
         # Identifier for the segment the cursor is currently in. None if no
@@ -158,7 +157,7 @@ class RawFactEntry(Gtk.Entry):
     # Callbacks
     def _on_facts_changed(self, evt):
         """Callback triggered when facts have changed."""
-        self.set_completion(RawFactCompletion(self._controller, self._config))
+        self.set_completion(RawFactCompletion(self._app))
 
     def _on_changed(self, widget):
         """
@@ -214,11 +213,10 @@ class RawFactCompletion(Gtk.EntryCompletion):
         Gtk.EntryCompletion: Completion instance.
     """
 
-    def __init__(self, controller, config, *args, **kwargs):
+    def __init__(self, app, *args, **kwargs):
         """Instantiate class."""
         super(RawFactCompletion, self).__init__(*args, **kwargs)
-        self._controller = controller
-        self._config = config
+        self._app = app
         self._activities_model, self._categories_model, self._activities_with_categories_model = (
             self._get_stores()
         )
@@ -268,8 +266,8 @@ class RawFactCompletion(Gtk.EntryCompletion):
         for autocomplete suggestions.
         """
         today = datetime.date.today()
-        start = today - datetime.timedelta(days=self._config['autocomplete_activities_offset'])
-        recent_activities = [fact.activity for fact in self._controller.facts.get_all(
+        start = today - datetime.timedelta(days=self._app.config['autocomplete_activities_offset'])
+        recent_activities = [fact.activity for fact in self._app.controller.facts.get_all(
             start=start, end=today)]
         return OrderedSet(recent_activities)
 

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -208,6 +208,7 @@ class RawFactEntry(Gtk.Entry):
     def _on_config_changed(self, evt):
         self._split_activity_autocomplete = self._app._config['autocomplete_split_activity']
 
+
 class RawFactCompletion(Gtk.EntryCompletion):
     """
     Return a completion instance to match 'activity@category' strings.

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -74,7 +74,6 @@ class RawFactEntry(Gtk.Entry):
         """
         super(RawFactEntry, self).__init__(*args, **kwargs)
         self._app = app
-        self._app.controller.signal_handler.connect('facts-changed', self._on_facts_changed)
         self._split_activity_autocomplete = split_activity_autocomplete
         self.set_completion(RawFactCompletion(app))
         # The re.match instance of the current string or None
@@ -83,6 +82,8 @@ class RawFactEntry(Gtk.Entry):
         # match is available.
         self.current_segment = None
         self.connect('changed', self._on_changed)
+        self._app.controller.signal_handler.connect('config-changed', self._on_config_changed)
+        self._app.controller.signal_handler.connect('facts-changed', self._on_facts_changed)
 
     def replace_segment_text(self, segment_string,):
         """
@@ -204,6 +205,8 @@ class RawFactEntry(Gtk.Entry):
             if self.current_segment in ('activity', 'category', 'activity+category'):
                 run_autocomplete(self.current_segment)
 
+    def _on_config_changed(self, evt):
+        self._split_activity_autocomplete = self._app._config['autocomplete_split_activity']
 
 class RawFactCompletion(Gtk.EntryCompletion):
     """

--- a/hamster_gtk/misc/widgets/raw_fact_entry.py
+++ b/hamster_gtk/misc/widgets/raw_fact_entry.py
@@ -268,7 +268,7 @@ class RawFactCompletion(Gtk.EntryCompletion):
         for autocomplete suggestions.
         """
         today = datetime.date.today()
-        start = today - datetime.timedelta(self._config['autocomplete_activities_offset'])
+        start = today - datetime.timedelta(days=self._config['autocomplete_activities_offset'])
         recent_activities = [fact.activity for fact in self._controller.facts.get_all(
             start=start, end=today)]
         return OrderedSet(recent_activities)

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -75,7 +75,7 @@ class PreferencesDialog(Gtk.Dialog):
                 ('tmpfile_path', (_('_Temporary file'), ComboFileChooser())),
             ]))),
             (_('Miscellaneous'), LabelledWidgetsGrid(collections.OrderedDict([
-                ('autocomplete_activities_offset', (_("Autocomplete Activities Offset"),
+                ('autocomplete_activities_range', (_("Autocomplete Activities Range"),
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
                 ('autocomplete_split_activity',
                  (_("Autocomplete activities and categories separately"),

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -32,7 +32,9 @@ from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 from hamster_gtk.preferences.widgets import (ComboFileChooser,
                                              HamsterComboBoxText,
                                              HamsterSpinButton,
-                                             SimpleAdjustment, TimeEntry)
+                                             HamsterCheckButton,
+                                             SimpleAdjustment,
+                                             TimeEntry)
 
 
 class PreferencesDialog(Gtk.Dialog):
@@ -76,6 +78,8 @@ class PreferencesDialog(Gtk.Dialog):
             (_('Miscellaneous'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('autocomplete_activities_offset', (_("Autocomplete Activities Offset"),
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
+                ('autocomplete_split_activity', (_("Autocomplete Split Activity"),
+                    HamsterCheckButton())),
             ]))),
         ]
 

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -77,7 +77,7 @@ class PreferencesDialog(Gtk.Dialog):
             (_('Miscellaneous'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('autocomplete_activities_offset', (_("Autocomplete Activities Offset"),
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
-                ('autocomplete_split_activity', (_("Autocomplete Split Activity"),
+                ('autocomplete_split_activity', (_("Autocomplete activities and categories separately"),
                     HamsterCheckButton())),
             ]))),
         ]

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -30,11 +30,10 @@ from gi.repository import GObject, Gtk
 
 from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 from hamster_gtk.preferences.widgets import (ComboFileChooser,
+                                             HamsterCheckButton,
                                              HamsterComboBoxText,
                                              HamsterSpinButton,
-                                             HamsterCheckButton,
-                                             SimpleAdjustment,
-                                             TimeEntry)
+                                             SimpleAdjustment, TimeEntry)
 
 
 class PreferencesDialog(Gtk.Dialog):

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -73,6 +73,10 @@ class PreferencesDialog(Gtk.Dialog):
                 ('db_path', (_('DB _Path'), ComboFileChooser())),
                 ('tmpfile_path', (_('_Temporary file'), ComboFileChooser())),
             ]))),
+            (_('Misc'), LabelledWidgetsGrid(collections.OrderedDict([
+                ('autocomplete_activities_offset', (_("Autocomplete Activities Offset"),
+                    HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
+            ]))),
         ]
 
         notebook = Gtk.Notebook()

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -77,8 +77,9 @@ class PreferencesDialog(Gtk.Dialog):
             (_('Miscellaneous'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('autocomplete_activities_offset', (_("Autocomplete Activities Offset"),
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
-                ('autocomplete_split_activity', (_("Autocomplete activities and categories separately"),
-                    HamsterCheckButton())),
+                ('autocomplete_split_activity',
+                 (_("Autocomplete activities and categories separately"),
+                  HamsterCheckButton())),
             ]))),
         ]
 

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -30,7 +30,7 @@ from gi.repository import GObject, Gtk
 
 from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 from hamster_gtk.preferences.widgets import (ComboFileChooser,
-                                             HamsterCheckButton,
+                                             HamsterSwitch,
                                              HamsterComboBoxText,
                                              HamsterSpinButton,
                                              SimpleAdjustment, TimeEntry)
@@ -79,7 +79,7 @@ class PreferencesDialog(Gtk.Dialog):
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
                 ('autocomplete_split_activity',
                  (_("Autocomplete activities and categories separately"),
-                  HamsterCheckButton())),
+                  HamsterSwitch())),
             ]))),
         ]
 

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -73,7 +73,7 @@ class PreferencesDialog(Gtk.Dialog):
                 ('db_path', (_('DB _Path'), ComboFileChooser())),
                 ('tmpfile_path', (_('_Temporary file'), ComboFileChooser())),
             ]))),
-            (_('Misc'), LabelledWidgetsGrid(collections.OrderedDict([
+            (_('Miscellaneous'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('autocomplete_activities_offset', (_("Autocomplete Activities Offset"),
                     HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
             ]))),

--- a/hamster_gtk/preferences/widgets/__init__.py
+++ b/hamster_gtk/preferences/widgets/__init__.py
@@ -19,7 +19,7 @@
 
 from .combo_file_chooser import ComboFileChooser  # NOQA
 from .config_widget import ConfigWidget  # NOQA
+from .hamster_check_button import HamsterCheckButton  # NOQA
 from .hamster_combo_box_text import HamsterComboBoxText  # NOQA
 from .hamster_spin_button import HamsterSpinButton, SimpleAdjustment  # NOQA
-from .hamster_check_button import HamsterCheckButton  # NOQA
 from .time_entry import TimeEntry  # NOQA

--- a/hamster_gtk/preferences/widgets/__init__.py
+++ b/hamster_gtk/preferences/widgets/__init__.py
@@ -19,7 +19,7 @@
 
 from .combo_file_chooser import ComboFileChooser  # NOQA
 from .config_widget import ConfigWidget  # NOQA
-from .hamster_check_button import HamsterCheckButton  # NOQA
+from .hamster_switch import HamsterSwitch  # NOQA
 from .hamster_combo_box_text import HamsterComboBoxText  # NOQA
 from .hamster_spin_button import HamsterSpinButton, SimpleAdjustment  # NOQA
 from .time_entry import TimeEntry  # NOQA

--- a/hamster_gtk/preferences/widgets/__init__.py
+++ b/hamster_gtk/preferences/widgets/__init__.py
@@ -21,4 +21,5 @@ from .combo_file_chooser import ComboFileChooser  # NOQA
 from .config_widget import ConfigWidget  # NOQA
 from .hamster_combo_box_text import HamsterComboBoxText  # NOQA
 from .hamster_spin_button import HamsterSpinButton, SimpleAdjustment  # NOQA
+from .hamster_check_button import HamsterCheckButton  # NOQA
 from .time_entry import TimeEntry  # NOQA

--- a/hamster_gtk/preferences/widgets/hamster_check_button.py
+++ b/hamster_gtk/preferences/widgets/hamster_check_button.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module provides ComboBoxText widget extended to store preferences."""
+"""This module provides a HamsterCheckButton widget that implements the ConfigWidget mixin."""
 
 from __future__ import absolute_import
 

--- a/hamster_gtk/preferences/widgets/hamster_check_button.py
+++ b/hamster_gtk/preferences/widgets/hamster_check_button.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of 'hamster-gtk'.
+#
+# 'hamster-gtk' is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# 'hamster-gtk' is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
+
+"""This module provides ComboBoxText widget extended to store preferences."""
+
+from __future__ import absolute_import
+
+from gi.repository import Gtk
+
+from .config_widget import ConfigWidget
+
+
+class HamsterCheckButton(Gtk.CheckButton, ConfigWidget):
+    """A ToggleButton that implements our unified custom ConfigWidget interface."""
+
+    # Required else you would need to specify the full module name in ui file
+    __gtype_name__ = 'HamsterCheckButton'
+
+    def __init__(self, active=False):
+        """
+        Initialize widget.
+
+        Args:
+            active (bool, optional): State of the button. Defaults to ``False``.
+        """
+        super(Gtk.CheckButton, self).__init__()
+
+    def get_config_value(self):
+        """
+        Return the id of the selected item.
+
+        Returns:
+            bool: ``True`` if state is ``active``, ``False`` else.
+        """
+        return self.get_active()
+
+    def set_config_value(self, active):
+        """
+        Set button state according to passed value.
+
+        Args:
+            active (bool): If ``True`` button will be set to ``active``. ``inactive`` else.
+        """
+        self.set_active(active)

--- a/hamster_gtk/preferences/widgets/hamster_switch.py
+++ b/hamster_gtk/preferences/widgets/hamster_switch.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with 'hamster-gtk'.  If not, see <http://www.gnu.org/licenses/>.
 
-"""This module provides a HamsterCheckButton widget that implements the ConfigWidget mixin."""
+"""This module provides a HamsterSwitch widget that implements the ConfigWidget mixin."""
 
 from __future__ import absolute_import
 
@@ -24,11 +24,11 @@ from gi.repository import Gtk
 from .config_widget import ConfigWidget
 
 
-class HamsterCheckButton(Gtk.CheckButton, ConfigWidget):
+class HamsterSwitch(Gtk.Switch, ConfigWidget):
     """A ToggleButton that implements our unified custom ConfigWidget interface."""
 
     # Required else you would need to specify the full module name in ui file
-    __gtype_name__ = 'HamsterCheckButton'
+    __gtype_name__ = 'HamsterSwitch'
 
     def __init__(self, active=False):
         """
@@ -37,7 +37,8 @@ class HamsterCheckButton(Gtk.CheckButton, ConfigWidget):
         Args:
             active (bool, optional): State of the button. Defaults to ``False``.
         """
-        super(Gtk.CheckButton, self).__init__()
+        super(Gtk.Switch, self).__init__()
+        self.set_active(active)
 
     def get_config_value(self):
         """

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -36,17 +36,18 @@ from hamster_gtk.misc.widgets import RawFactEntry
 class TrackingScreen(Gtk.Stack):
     """Main container for the tracking screen."""
 
-    def __init__(self, controller, *args, **kwargs):
+    def __init__(self, controller, config, *args, **kwargs):
         """Setup widget."""
         super(TrackingScreen, self).__init__(*args, **kwargs)
         self._controller = controller
+        self._config = config
 
         self.main_window = helpers.get_parent_window(self)
         self.set_transition_type(Gtk.StackTransitionType.SLIDE_UP)
         self.set_transition_duration(1000)
         self.current_fact_view = CurrentFactBox(self._controller)
         self.current_fact_view.connect('tracking-stopped', self.update)
-        self.start_tracking_view = StartTrackingBox(self._controller)
+        self.start_tracking_view = StartTrackingBox(self._controller, self._config)
         self.start_tracking_view.connect('tracking-started', self.update)
         self.add_titled(self.start_tracking_view, 'start tracking', _("Start Tracking"))
         self.add_titled(self.current_fact_view, 'ongoing fact', _("Show Ongoing Fact"))
@@ -163,11 +164,12 @@ class StartTrackingBox(Gtk.Box):
     # [FIXME]
     # Switch to Grid based layout.
 
-    def __init__(self, controller, *args, **kwargs):
+    def __init__(self, controller, config, *args, **kwargs):
         """Setup widget."""
         super(StartTrackingBox, self).__init__(orientation=Gtk.Orientation.VERTICAL,
                                                spacing=10, *args, **kwargs)
         self._controller = controller
+        self._config = config
         self.set_homogeneous(False)
 
         # [FIXME]
@@ -178,7 +180,7 @@ class StartTrackingBox(Gtk.Box):
         self.pack_start(self.current_fact_label, False, False, 0)
 
         # Fact entry field
-        self.raw_fact_entry = RawFactEntry(self._controller)
+        self.raw_fact_entry = RawFactEntry(self._controller, self._config)
         self.raw_fact_entry.connect('activate', self._on_raw_fact_entry_activate)
         self.pack_start(self.raw_fact_entry, False, False, 0)
 

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -78,13 +78,13 @@ class CurrentFactBox(Gtk.Box):
         str('tracking-stopped'): (GObject.SIGNAL_RUN_LAST, GObject.TYPE_NONE, ()),
     }
 
-    def __init__(self, app):
+    def __init__(self, controller):
         """Setup widget."""
         # We need to wrap this in a vbox to limit its vertical expansion.
         # [FIXME]
         # Switch to Grid based layout.
         super(CurrentFactBox, self).__init__(orientation=Gtk.Orientation.VERTICAL, spacing=10)
-        self._app = app
+        self._controller = controller
         self.content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         self.pack_start(self.content, False, False, 0)
 
@@ -95,7 +95,7 @@ class CurrentFactBox(Gtk.Box):
 
         if not fact:
             try:
-                fact = self._app.controller.store.facts.get_tmp_fact()
+                fact = self._controller.store.facts.get_tmp_fact()
             except KeyError:
                 # This should never be seen by the user. It would mean that a
                 # switch to this screen has been triggered without an ongoing
@@ -131,7 +131,7 @@ class CurrentFactBox(Gtk.Box):
         Discard current *ongoing fact* without saving.
         """
         try:
-            self._app.controller.store.facts.cancel_tmp_fact()
+            self._controller.store.facts.cancel_tmp_fact()
         except KeyError as err:
             helpers.show_error(helpers.get_parent_window(self), err)
         else:
@@ -144,13 +144,13 @@ class CurrentFactBox(Gtk.Box):
         Save *ongoing fact* to storage.
         """
         try:
-            self._app.controller.store.facts.stop_tmp_fact()
+            self._controller.store.facts.stop_tmp_fact()
         except Exception as error:
             helpers.show_error(helpers.get_parent_window(self), error)
         else:
             self.emit('tracking-stopped')
             # Inform the controller about the chance.
-            self._app.controller.signal_handler.emit('facts-changed')
+            self._controller.signal_handler.emit('facts-changed')
 
 
 class StartTrackingBox(Gtk.Box):

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -178,7 +178,8 @@ class StartTrackingBox(Gtk.Box):
         self.pack_start(self.current_fact_label, False, False, 0)
 
         # Fact entry field
-        self.raw_fact_entry = RawFactEntry(self._app)
+        autocomplete_split_activity = self._app._config['autocomplete_split_activity']
+        self.raw_fact_entry = RawFactEntry(self._app, autocomplete_split_activity)
         self.raw_fact_entry.connect('activate', self._on_raw_fact_entry_activate)
         self.pack_start(self.raw_fact_entry, False, False, 0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,5 +108,6 @@ def config(request, tmpdir):
         'db_engine': 'sqlite',
         'db_path': ':memory:',
         'autocomplete_activities_offset': 30,
+        'autocomplete_split_activity': False,
     }
     return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,5 +107,6 @@ def config(request, tmpdir):
         'tmpfile_path': tmpdir.join('tmpfile.hamster'),
         'db_engine': 'sqlite',
         'db_path': ':memory:',
+        'autocomplete_activities_offset': 30,
     }
     return config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def config(request, tmpdir):
         'tmpfile_path': tmpdir.join('tmpfile.hamster'),
         'db_engine': 'sqlite',
         'db_path': ':memory:',
-        'autocomplete_activities_offset': 30,
+        'autocomplete_activities_range': 30,
         'autocomplete_split_activity': False,
     }
     return config

--- a/tests/misc/conftest.py
+++ b/tests/misc/conftest.py
@@ -71,13 +71,13 @@ def edit_fact_dialog(request, fact, dummy_window):
 @pytest.fixture
 def raw_fact_entry(request, app):
     """Return a ``RawFactEntry`` instance."""
-    return widgets.RawFactEntry(app.controller)
+    return widgets.RawFactEntry(app.controller, app.config)
 
 
 @pytest.fixture
 def raw_fact_completion(request, app):
     """Return a RawFactCompletion`` instance."""
-    return widgets.raw_fact_entry.RawFactCompletion(app.controller)
+    return widgets.raw_fact_entry.RawFactCompletion(app.controller, app.config)
 
 
 @pytest.fixture

--- a/tests/misc/conftest.py
+++ b/tests/misc/conftest.py
@@ -71,13 +71,13 @@ def edit_fact_dialog(request, fact, dummy_window):
 @pytest.fixture
 def raw_fact_entry(request, app):
     """Return a ``RawFactEntry`` instance."""
-    return widgets.RawFactEntry(app.controller, app.config)
+    return widgets.RawFactEntry(app)
 
 
 @pytest.fixture
 def raw_fact_completion(request, app):
     """Return a RawFactCompletion`` instance."""
-    return widgets.raw_fact_entry.RawFactCompletion(app.controller, app.config)
+    return widgets.raw_fact_entry.RawFactCompletion(app)
 
 
 @pytest.fixture

--- a/tests/misc/widgets/conftest.py
+++ b/tests/misc/widgets/conftest.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, unicode_literals
 import collections
 
 import pytest
+
 from hamster_gtk.misc import widgets
 from hamster_gtk.preferences.widgets import (ComboFileChooser,
                                              HamsterComboBoxText)

--- a/tests/misc/widgets/test_raw_fact_completion.py
+++ b/tests/misc/widgets/test_raw_fact_completion.py
@@ -29,20 +29,20 @@ from hamster_gtk.misc.widgets.raw_fact_entry import RawFactCompletion
 
 def test_init(app, mocker):
     """Test instantiation."""
-    result = RawFactCompletion(app.controller)
+    result = RawFactCompletion(app)
     assert result.get_model()
     assert result.get_text_column() == 0
 
 
 def test__get_stores(raw_fact_completion, activity_factory, mocker):
-    """Make sure the ``ListStore`` is constructed to our expectations."""
+    """Make sure the ``ListStore`` is populated to our expectations."""
     raw_fact_completion._get_activities = mocker.MagicMock(
-        return_value=activity_factory.build_batch(10))
-    result = raw_fact_completion._get_stores()
+        return_value=activity_factory.build_batch(5))
+    raw_fact_completion._populate_stores(None)
     assert raw_fact_completion._get_activities.called
-    for store in result:
+    for key, store in raw_fact_completion.segment_models.items():
         assert isinstance(store, Gtk.ListStore)
-        assert len(store) == 10
+        assert len(store) == 5
 
 
 def test__get_activities(app, raw_fact_completion, fact_factory, mocker):

--- a/tests/misc/widgets/test_raw_fact_entry.py
+++ b/tests/misc/widgets/test_raw_fact_entry.py
@@ -24,7 +24,7 @@ from hamster_gtk.misc.widgets import RawFactEntry
 
 
 def test_init(app):
-        assert RawFactEntry(app.controller)
+        assert RawFactEntry(app)
 
 
 def test__on_facts_changed(raw_fact_entry):

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -74,10 +74,17 @@ def autocomplete_activities_offset_parametrized(request):
     return request.param
 
 
+@pytest.fixture(params=(True, False))
+def autocomplete_split_activity_parametrized(request):
+    """Return a parametrized autocomplete_activities_offset value."""
+    return request.param
+
+
 @pytest.fixture
 def config_parametrized(request, store_parametrized, day_start_parametrized,
         fact_min_delta_parametrized, tmpfile_path_parametrized, db_engine_parametrized,
-        db_path_parametrized, autocomplete_activities_offset_parametrized):
+        db_path_parametrized, autocomplete_activities_offset_parametrized,
+        autocomplete_split_activity_parametrized):
             """Return a config fixture with heavily parametrized config values."""
             return {
                 'store': store_parametrized,
@@ -87,6 +94,7 @@ def config_parametrized(request, store_parametrized, day_start_parametrized,
                 'db_engine': db_engine_parametrized,
                 'db_path': db_path_parametrized,
                 'autocomplete_activities_offset': autocomplete_activities_offset_parametrized,
+                'autocomplete_split_activity': autocomplete_split_activity_parametrized,
             }
 
 

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -69,21 +69,21 @@ def db_path_parametrized(request, tmpdir):
 
 
 @pytest.fixture(params=(0, 1, 30, 60))
-def autocomplete_activities_offset_parametrized(request):
-    """Return a parametrized autocomplete_activities_offset value."""
+def autocomplete_activities_range_parametrized(request):
+    """Return a parametrized autocomplete_activities_range value."""
     return request.param
 
 
 @pytest.fixture(params=(True, False))
 def autocomplete_split_activity_parametrized(request):
-    """Return a parametrized autocomplete_activities_offset value."""
+    """Return a parametrized autocomplete_split_activity value."""
     return request.param
 
 
 @pytest.fixture
 def config_parametrized(request, store_parametrized, day_start_parametrized,
         fact_min_delta_parametrized, tmpfile_path_parametrized, db_engine_parametrized,
-        db_path_parametrized, autocomplete_activities_offset_parametrized,
+        db_path_parametrized, autocomplete_activities_range_parametrized,
         autocomplete_split_activity_parametrized):
             """Return a config fixture with heavily parametrized config values."""
             return {
@@ -93,7 +93,7 @@ def config_parametrized(request, store_parametrized, day_start_parametrized,
                 'tmpfile_path': tmpfile_path_parametrized,
                 'db_engine': db_engine_parametrized,
                 'db_path': db_path_parametrized,
-                'autocomplete_activities_offset': autocomplete_activities_offset_parametrized,
+                'autocomplete_activities_range': autocomplete_activities_range_parametrized,
                 'autocomplete_split_activity': autocomplete_split_activity_parametrized,
             }
 

--- a/tests/preferences/conftest.py
+++ b/tests/preferences/conftest.py
@@ -68,10 +68,16 @@ def db_path_parametrized(request, tmpdir):
     return path
 
 
+@pytest.fixture(params=(0, 1, 30, 60))
+def autocomplete_activities_offset_parametrized(request):
+    """Return a parametrized autocomplete_activities_offset value."""
+    return request.param
+
+
 @pytest.fixture
 def config_parametrized(request, store_parametrized, day_start_parametrized,
         fact_min_delta_parametrized, tmpfile_path_parametrized, db_engine_parametrized,
-        db_path_parametrized):
+        db_path_parametrized, autocomplete_activities_offset_parametrized):
             """Return a config fixture with heavily parametrized config values."""
             return {
                 'store': store_parametrized,
@@ -80,6 +86,7 @@ def config_parametrized(request, store_parametrized, day_start_parametrized,
                 'tmpfile_path': tmpfile_path_parametrized,
                 'db_engine': db_engine_parametrized,
                 'db_path': db_path_parametrized,
+                'autocomplete_activities_offset': autocomplete_activities_offset_parametrized,
             }
 
 

--- a/tests/preferences/test_preferences_dialog.py
+++ b/tests/preferences/test_preferences_dialog.py
@@ -19,7 +19,7 @@ class TestPreferencesDialog(object):
         grids = result.get_content_area().get_children()[0].get_children()
         # This assumes 2 children per config entry (label and widget).
         grid_entry_counts = [len(g.get_children()) / 2 for g in grids]
-        assert sum(grid_entry_counts) == 7
+        assert sum(grid_entry_counts) == 8
 
     def test_get_config(self, preferences_dialog, config_parametrized):
         """

--- a/tests/preferences/test_preferences_dialog.py
+++ b/tests/preferences/test_preferences_dialog.py
@@ -19,7 +19,7 @@ class TestPreferencesDialog(object):
         grids = result.get_content_area().get_children()[0].get_children()
         # This assumes 2 children per config entry (label and widget).
         grid_entry_counts = [len(g.get_children()) / 2 for g in grids]
-        assert sum(grid_entry_counts) == 6
+        assert sum(grid_entry_counts) == 7
 
     def test_get_config(self, preferences_dialog, config_parametrized):
         """

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -29,7 +29,7 @@ class TestHamsterGTK(object):
     def test__get_default_config(self, app, appdirs):
         """Make sure the defaults use appdirs for relevant paths."""
         result = app._get_default_config()
-        assert len(result) == 6
+        assert len(result) == 7
         assert os.path.dirname(result['tmpfile_path']) == appdirs.user_data_dir
         assert os.path.dirname(result['db_path']) == appdirs.user_data_dir
 

--- a/tests/test_hamster-gtk.py
+++ b/tests/test_hamster-gtk.py
@@ -29,7 +29,7 @@ class TestHamsterGTK(object):
     def test__get_default_config(self, app, appdirs):
         """Make sure the defaults use appdirs for relevant paths."""
         result = app._get_default_config()
-        assert len(result) == 7
+        assert len(result) == 8
         assert os.path.dirname(result['tmpfile_path']) == appdirs.user_data_dir
         assert os.path.dirname(result['db_path']) == appdirs.user_data_dir
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from gi.repository import Gtk
-
 import pytest
+from gi.repository import Gtk
 
 import hamster_gtk.helpers as helpers
 

--- a/tests/tracking/conftest.py
+++ b/tests/tracking/conftest.py
@@ -12,16 +12,16 @@ from hamster_gtk.tracking import screens
 @pytest.fixture
 def tracking_screen(request, app):
     """Return a plain TrackingScreen instance."""
-    return screens.TrackingScreen(app.controller, app.config)
+    return screens.TrackingScreen(app)
 
 
 @pytest.fixture
 def start_tracking_box(request, app):
     """Provide a plain StartTrackingBox instance."""
-    return screens.StartTrackingBox(app.controller, app.config)
+    return screens.StartTrackingBox(app)
 
 
 @pytest.fixture
 def current_fact_box(request, app):
     """Provide a plain CurrentFactBox instance."""
-    return screens.CurrentFactBox(app.controller)
+    return screens.CurrentFactBox(app)

--- a/tests/tracking/conftest.py
+++ b/tests/tracking/conftest.py
@@ -12,13 +12,13 @@ from hamster_gtk.tracking import screens
 @pytest.fixture
 def tracking_screen(request, app):
     """Return a plain TrackingScreen instance."""
-    return screens.TrackingScreen(app.controller)
+    return screens.TrackingScreen(app.controller, app.config)
 
 
 @pytest.fixture
 def start_tracking_box(request, app):
     """Provide a plain StartTrackingBox instance."""
-    return screens.StartTrackingBox(app.controller)
+    return screens.StartTrackingBox(app.controller, app.config)
 
 
 @pytest.fixture

--- a/tests/tracking/conftest.py
+++ b/tests/tracking/conftest.py
@@ -24,4 +24,4 @@ def start_tracking_box(request, app):
 @pytest.fixture
 def current_fact_box(request, app):
     """Provide a plain CurrentFactBox instance."""
-    return screens.CurrentFactBox(app)
+    return screens.CurrentFactBox(app.controller)

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -15,7 +15,7 @@ class TestTrackingScreen(object):
 
     def test_init(self, app):
         """Make sure instance matches expectation."""
-        result = screens.TrackingScreen(app.controller)
+        result = screens.TrackingScreen(app.controller, app.config)
         assert isinstance(result, screens.TrackingScreen)
         assert len(result.get_children()) == 2
 
@@ -44,7 +44,7 @@ class TestStartTrackingBox(object):
 
     def test_init(self, app):
         """Make sure instances matches expectation."""
-        result = screens.StartTrackingBox(app.controller)
+        result = screens.StartTrackingBox(app.controller, app.config)
         assert isinstance(result, screens.StartTrackingBox)
         assert len(result.get_children()) == 3
 

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -69,7 +69,7 @@ class TestCurrentFactBox(object):
     """Unittests for CurrentFactBox."""
 
     def test_init(self, app):
-        result = screens.CurrentFactBox(app)
+        result = screens.CurrentFactBox(app.controller)
         assert isinstance(result, screens.CurrentFactBox)
 
     def test_update_initial_fact(self, current_fact_box, fact):
@@ -104,16 +104,16 @@ class TestCurrentFactBox(object):
 
     def test_on_cancel_buton(self, request, current_fact_box, mocker):
         """Make sure that 'tracking-stopped' signal is emitted."""
-        current_fact_box._app.controller.store.facts.cancel_tmp_fact = mocker.MagicMock()
+        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock()
         current_fact_box.emit = mocker.MagicMock()
         result = current_fact_box._on_cancel_button(None)
-        assert current_fact_box._app.controller.store.facts.cancel_tmp_fact.called
+        assert current_fact_box._controller.store.facts.cancel_tmp_fact.called
         assert result is None
         assert current_fact_box.emit.called_with('tracking-stopped')
 
     def test_on_cancel_buton_expected_exception(self, request, current_fact_box, mocker):
         """Make sure that we show error dialog if we encounter an expected exception."""
-        current_fact_box._app.controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
+        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
             side_effect=KeyError)
         show_error = mocker.patch('hamster_gtk.tracking.screens.helpers.show_error')
         current_fact_box.emit = mocker.MagicMock()
@@ -124,7 +124,7 @@ class TestCurrentFactBox(object):
 
     def test_on_cancel_buton_unexpected_exception(self, request, current_fact_box, mocker):
         """Make sure that we do not intercept unexpected exceptions."""
-        current_fact_box._app.controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
+        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
             side_effect=Exception)
         with pytest.raises(Exception):
             current_fact_box._on_cancel_button(None)

--- a/tests/tracking/test_screens.py
+++ b/tests/tracking/test_screens.py
@@ -15,14 +15,14 @@ class TestTrackingScreen(object):
 
     def test_init(self, app):
         """Make sure instance matches expectation."""
-        result = screens.TrackingScreen(app.controller, app.config)
+        result = screens.TrackingScreen(app)
         assert isinstance(result, screens.TrackingScreen)
         assert len(result.get_children()) == 2
 
     def test_update_with_ongoing_fact(self, tracking_screen, fact, mocker):
         """Make sure current fact view is shown."""
         fact.end is None
-        tracking_screen._controller.store.facts.get_tmp_fact = mocker.MagicMock(
+        tracking_screen._app.controller.store.facts.get_tmp_fact = mocker.MagicMock(
             return_value=fact)
         tracking_screen.update()
         result = tracking_screen.get_visible_child()
@@ -31,7 +31,7 @@ class TestTrackingScreen(object):
 
     def test_update_with_no_ongoing_fact(self, tracking_screen, mocker):
         """Make sure start tracking view is shown."""
-        tracking_screen._controller.store.facts.get_tmp_fact = mocker.MagicMock(
+        tracking_screen._app.controller.store.facts.get_tmp_fact = mocker.MagicMock(
             side_effect=KeyError)
         tracking_screen.update()
         result = tracking_screen.get_visible_child()
@@ -44,7 +44,7 @@ class TestStartTrackingBox(object):
 
     def test_init(self, app):
         """Make sure instances matches expectation."""
-        result = screens.StartTrackingBox(app.controller, app.config)
+        result = screens.StartTrackingBox(app)
         assert isinstance(result, screens.StartTrackingBox)
         assert len(result.get_children()) == 3
 
@@ -52,11 +52,11 @@ class TestStartTrackingBox(object):
         """Make sure a new 'ongoing fact' is created."""
         # [FIXME]
         # We need to find a viable way to check if signals are emitted!
-        start_tracking_box._controller.store.facts.save = mocker.MagicMock()
+        start_tracking_box._app.controller.store.facts.save = mocker.MagicMock()
         raw_fact = '{fact.activity.name}@{fact.category.name}'.format(fact=fact)
         start_tracking_box.raw_fact_entry.props.text = raw_fact
         start_tracking_box._on_start_tracking_button(None)
-        assert start_tracking_box._controller.store.facts.save.called
+        assert start_tracking_box._app.controller.store.facts.save.called
 
     def test__reset(self, start_tracking_box):
         """Make sure all relevant widgets are reset."""
@@ -69,7 +69,7 @@ class TestCurrentFactBox(object):
     """Unittests for CurrentFactBox."""
 
     def test_init(self, app):
-        result = screens.CurrentFactBox(app.controller)
+        result = screens.CurrentFactBox(app)
         assert isinstance(result, screens.CurrentFactBox)
 
     def test_update_initial_fact(self, current_fact_box, fact):
@@ -104,16 +104,16 @@ class TestCurrentFactBox(object):
 
     def test_on_cancel_buton(self, request, current_fact_box, mocker):
         """Make sure that 'tracking-stopped' signal is emitted."""
-        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock()
+        current_fact_box._app.controller.store.facts.cancel_tmp_fact = mocker.MagicMock()
         current_fact_box.emit = mocker.MagicMock()
         result = current_fact_box._on_cancel_button(None)
-        assert current_fact_box._controller.store.facts.cancel_tmp_fact.called
+        assert current_fact_box._app.controller.store.facts.cancel_tmp_fact.called
         assert result is None
         assert current_fact_box.emit.called_with('tracking-stopped')
 
     def test_on_cancel_buton_expected_exception(self, request, current_fact_box, mocker):
         """Make sure that we show error dialog if we encounter an expected exception."""
-        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
+        current_fact_box._app.controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
             side_effect=KeyError)
         show_error = mocker.patch('hamster_gtk.tracking.screens.helpers.show_error')
         current_fact_box.emit = mocker.MagicMock()
@@ -124,7 +124,7 @@ class TestCurrentFactBox(object):
 
     def test_on_cancel_buton_unexpected_exception(self, request, current_fact_box, mocker):
         """Make sure that we do not intercept unexpected exceptions."""
-        current_fact_box._controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
+        current_fact_box._app.controller.store.facts.cancel_tmp_fact = mocker.MagicMock(
             side_effect=Exception)
         with pytest.raises(Exception):
             current_fact_box._on_cancel_button(None)


### PR DESCRIPTION
This PR introduces a new config key ``autocomplete_activities_offset`` which is expected to be an integer.
When autocompleting raw facts a set of 'recent activities' is fetched. This new config value will determine the number of days before today that should be the start for this collection of 'recent activities'.
We also add another new config key ``autocomplete_split_activity`` which is a boolean and governs if a typed string will be matched against ``activity.name`` and ``activity.category.name`` individually or in conjunction.

Closes: #168 