### PR TITLE
[#182] Fix compatibility with hamster-lib 0.13

### DIFF
--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -18,7 +18,8 @@ We do fully follow Donald Stuffts `argument
 ``setup.py`` is of fundamentally different nature than what may be located
 under ``requirements.txt`` (Additional comments can be found in the `packaging
 guide
-<https://python-packaging-user-guide.readthedocs.io/requirements/>`_
+<http://python-packaging-user-guide.readthedocs.io/discussions/install-requires-vs-requirements/>`_
+
 and with `Hynek Schlawack
 <https://hynek.me/articles/sharing-your-labor-of-love-pypi-quick-and-dirty/>`_).
 As far as packaging goes ``setup.py`` is authoritative. We provide a set of

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -39,9 +39,6 @@ from gi.repository import Gio, Gdk, GObject, Gtk
 from hamster_lib.helpers import config_helpers
 from six import text_type
 
-# [FIXME]
-# Remove once hamster-lib has been patched
-from hamster_gtk.helpers import get_config_instance
 from hamster_gtk.misc import HamsterAboutDialog as AboutDialog
 from hamster_gtk.overview import OverviewDialog
 from hamster_gtk.preferences import PreferencesDialog
@@ -139,6 +136,9 @@ class HamsterGTK(Gtk.Application):
         super(HamsterGTK, self).__init__()
         self.set_resource_base_path('/org/projecthamster/hamster-gtk')
         self.window = None
+
+        self._appdirs = config_helpers.HamsterAppDirs('hamster-gtk')
+
         # Which config backend to use.
         self.config_store = 'file'
         # Yes this is redundent, but more transparent. And we can worry about
@@ -162,7 +162,7 @@ class HamsterGTK(Gtk.Application):
             dict: Dictionary of config keys and values.
         """
         cp_instance = self._config_to_configparser(config)
-        config_helpers.write_config_file(cp_instance, 'hamster-gtk', 'hamster-gtk.conf')
+        config_helpers.write_config_file(cp_instance, self._appdirs, 'hamster-gtk.conf')
         self.controller.signal_handler.emit('config-changed')
 
     def _create_actions(self):
@@ -266,7 +266,7 @@ class HamsterGTK(Gtk.Application):
 
         Note: Those defaults are independend of the particular config store.
         """
-        appdirs = config_helpers.HamsterAppDirs('hamster-gtk')
+        appdirs = self._appdirs
         return {
             # Backend
             'store': 'sqlalchemy',
@@ -379,7 +379,7 @@ class HamsterGTK(Gtk.Application):
         Args:
             cp_instance (SafeConfigParser): Instance to be written to file.
         """
-        config_helpers.write_config_file(configparser_instance, 'hamster-gtk', 'hamster-gtk.conf')
+        config_helpers.write_config_file(configparser_instance, self._appdirs, 'hamster-gtk.conf')
 
     def _get_config_from_file(self):
         """
@@ -397,7 +397,8 @@ class HamsterGTK(Gtk.Application):
             config = self._get_default_config()
             return self._config_to_configparser(config)
 
-        cp_instance = get_config_instance(get_fallback(), 'hamster-gtk', 'hamster-gtk.conf')
+        cp_instance = config_helpers.load_config_file(self._appdirs, 'hamster-gtk.conf',
+            get_fallback())
         return self._configparser_to_config(cp_instance)
 
 

--- a/hamster_gtk/helpers.py
+++ b/hamster_gtk/helpers.py
@@ -117,23 +117,6 @@ def calendar_date_to_datetime(date):
     return datetime.date(int(year), int(month) + 1, int(day))
 
 
-# [FIXME]
-# Remove once hamster-lib is patched
-# This should probably be named/limited to: 'read_config_file'.
-# The 'fallback' behaviour should live with ``_get_config_from_file``.
-def get_config_instance(fallback_config_instance, app_name, file_name):
-    """Patched version of ``hamster-lib`` helper function until it get fixed upstream."""
-    from hamster_lib.helpers import config_helpers
-    from backports.configparser import SafeConfigParser
-    config = SafeConfigParser()
-    path = config_helpers.get_config_path(app_name, file_name)
-    existing_config = config.read(path)
-    if not existing_config:
-        config = config_helpers.write_config_file(fallback_config_instance, app_name,
-                                                  file_name=file_name)
-    return config
-
-
 def decompose_raw_fact_string(text, raw=False):
     """
     Try to match a given string with modular regex groups.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'orderedset',
-    'hamster-lib',
+    'hamster-lib >= 0.13.0',
 ]
 
 setup(


### PR DESCRIPTION
This PR updates our dependencies to require ``hamster-lib>=0.13.0``. As this introduces backwards incompatible changes with regards to the config helper, some additional compatibility fixes are included as well.

Closes: #182 