### PR TITLE
Exclude tests from installation

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -34,7 +34,7 @@ import hamster_lib
 # Once we drop py2 support, we can use the builtin again but unicode support
 # under python 2 is practically non existing and manual encoding is not easily
 # possible.
-from backports.configparser import SafeConfigParser
+from configparser import SafeConfigParser
 from gi.repository import Gdk, Gio, GObject, Gtk
 from hamster_lib.helpers import config_helpers
 from six import text_type

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ source = hamster_gtk
 
 [isort]
 not_skip = __init__.py
-known_third_party = backports, faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
+known_third_party = faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
 	past, pytest, pytest_factoryboy, six
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author="Eric Goller",
     author_email='eric.goller@projecthamster.org',
     url='https://github.com/projecthamster/hamster-gtk',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests*']),
     install_requires=requirements,
     license="GPL3",
     zip_safe=False,


### PR DESCRIPTION
Previously, the tests module was included when installing the application. This could lead to a conflict when another python package also exposed its tests and used a same file, for example `tests/helpers/__init__.py`.

This patch excludes the tests module from installation. The tests module will still be included in the distribution tarballs so that hamster-gtk can be tested before installation.

Closes: #189