### PR TITLE
Remove the use of backports namespace

### DIFF
--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -34,7 +34,7 @@ import hamster_lib
 # Once we drop py2 support, we can use the builtin again but unicode support
 # under python 2 is practically non existing and manual encoding is not easily
 # possible.
-from backports.configparser import SafeConfigParser
+from configparser import SafeConfigParser
 from gi.repository import Gdk, Gio, GObject, Gtk
 from hamster_lib.helpers import config_helpers
 from six import text_type

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ source = hamster_gtk
 
 [isort]
 not_skip = __init__.py
-known_third_party = backports, faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
+known_third_party = faker, factory, fauxfactory, freezegun, future, gi, hamster_lib,
 	past, pytest, pytest_factoryboy, six
 
 [tool:pytest]


### PR DESCRIPTION
Continuing with LIB-236, we also remove the namespace from hamster-gtk.

Closing: #124