### PR TITLE
Display seconds in Fact Edit dialogue

### DIFF
--- a/hamster_gtk/misc/dialogs/edit_fact_dialog.py
+++ b/hamster_gtk/misc/dialogs/edit_fact_dialog.py
@@ -119,8 +119,8 @@ class EditFactDialog(Gtk.Dialog):
         # [FIXME]
         # Maybe it would be sensible to have a serialization helper method as
         # part of ``hamster-lib``?!
-        start_string = self._fact.start.strftime('%Y-%m-%d %H:%M')
-        end_string = self._fact.end.strftime("%Y-%m-%d %H:%M")
+        start_string = self._fact.start.strftime('%Y-%m-%d %H:%M:%S')
+        end_string = self._fact.end.strftime("%Y-%m-%d %H:%M:%S")
         if self._fact.category is None:
             label = '{start} - {end} {activity}'.format(
                 start=start_string,


### PR DESCRIPTION
Because the raw fact editor did not display seconds, when saving a fact,
it could lead to conflict.

This commit adds seconds to the entry.

Closes: #187