### PR TITLE
[#199] Provide basic GNOME integration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,8 @@ recursive-exclude * *.sw?
 
 exclude ci
 recursive-exclude ci *
+
+# Files in ``misc`` should not be part of the sdist as they are not part of the
+# actual package but just a help for desktop integration and such.
+exclude misc
+recursive-exclude misc *

--- a/Makefile
+++ b/Makefile
@@ -19,24 +19,25 @@ BROWSER := python -c "$$BROWSER_PYSCRIPT"
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of"
-	@echo "   clean         to remove all build, test, coverage and Python artifacts"
-	@echo "   clean-build   to remove build artifacts"
-	@echo "   clean-pyc     to remove Python file artifacts"
+	@echo "   clean          to remove all build, test, coverage and Python artifacts"
+	@echo "   clean-build    to remove build artifacts"
+	@echo "   clean-pyc      to remove Python file artifacts"
 	@echo "   clean-docs"
-	@echo "   clean-test    to remove test and coverage artifacts"
-	@echo "   lint          to check style with flake8"
-	@echo "   test          to run tests quickly with the default Python"
-	@echo "   test-all      to run tests on every Python version with tox"
-	@echo "   coverage      to check code coverage quickly with the default Python"
+	@echo "   clean-test     to remove test and coverage artifacts"
+	@echo "   lint           to check style with flake8"
+	@echo "   test           to run tests quickly with the default Python"
+	@echo "   test-all       to run tests on every Python version with tox"
+	@echo "   coverage       to check code coverage quickly with the default Python"
 	@echo "   coverage-html"
 	@echo "   codecov"
-	@echo "   develop       to install (or update) all packages required for development"
-	@echo "   docs          to generate Sphinx HTML documentation, including API docs"
-	@echo "   isort         to run isort on the whole project."
-	@echo "   resources     to generate GTK resources"
-	@echo "   release       to package and upload a release"
-	@echo "   dist          to package"
-	@echo "   install       to install the package to the active Python's site-packages"
+	@echo "   develop        to install (or update) all packages required for development"
+	@echo "   docs           to generate Sphinx HTML documentation, including API docs"
+	@echo "   isort          to run isort on the whole project."
+	@echo "   resources      to generate GTK resources"
+	@echo "   release        to package and upload a release"
+	@echo "   dist           to package"
+	@echo "   install        to install the package to the active Python's site-packages"
+	@echo "   register-gnome to register the package as a GNOME Application."
 
 clean: clean-build clean-pyc clean-test
 
@@ -114,5 +115,8 @@ dist: resources
 	python setup.py bdist_wheel
 	ls -l dist
 
-install: clean
+install: clean resources
 	python setup.py install
+
+register-gnome:
+	desktop-file-install misc/org.projecthamster.hamster-gtk.desktop

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,9 @@ You have been warned.
 Dependencies
 -------------
 
+If you want to use the ``make register-gnome`` target ``desktop-file-install``
+is required. On debian derivates this is provided by ``desktop-file-utils``.
+
 To Run the Testsuite
 ~~~~~~~~~~~~~~~~~~~~~
 - make

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -133,7 +133,7 @@ class HamsterGTK(Gtk.Application):
 
     def __init__(self):
         """Setup instance and make sure default signals are connected to methods."""
-        super(HamsterGTK, self).__init__()
+        super(HamsterGTK, self).__init__(application_id='org.projecthamster.hamster-gtk')
         self.set_resource_base_path('/org/projecthamster/hamster-gtk')
         self.window = None
 

--- a/misc/org.projecthamster.hamster-gtk.desktop
+++ b/misc/org.projecthamster.hamster-gtk.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=hamster-gtk
+Exec=hamster-gtk
+Type=Application
+Terminal=false
+Encoding=UTF-8
+Categories=GTK;GNOME;Utility;
+Version=1.0


### PR DESCRIPTION
This commit integrates ``hamster-gtk`` as a integrated GNOME
application. In order to do so, a dedicated ``application__id`` is
assigned (which allows ``Gtk.Application`` to manage instance
uniqueness). Furthermore we now provide a ``*.desktop`` file with basic
metadata that is used to 'register' the app with GNOME.
To make this process as easy as possible, we also provide a new make
tarket ``register-gtk`` which uses the ``desktop-file-install`` helper
tool to handle copying the desktop file to the appropiate location.

On top of those changes this commit also makes sure that ``make
install`` will build a ``gresources`` file beforehand.

Closes: #197
Closes: #199