### PR TITLE
Bring proper unittests to hamster-gtk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,21 @@
-# Config file for automatic testing at travis-ci.org
-# This file will be regenerated if you run travis_pypi_setup.py
+sudo: false
 
-sudo: required
-dist: trusty
+os:
+  - linux
 
-language: python
+language:
+  - python
+
 python:
-    - "2.7"
+  - "2.7"
 
-# Even if we do not run our real code testsuite sphinx autodocs need access to GTK
-addons:
-  apt:
-    packages:
-    - gir1.2-pango-1.0
-    - gir1.2-gtk-3.0
-    - libglib2.0-dev
-    - libgtk-3-dev
-    - python-gi
-    - python-cairo
-    - python-gi-cairo
+services:
+  - docker
 
-virtualenv:
-  system_site_packages: true
-
-cache: pip
-
-install:
-  - pip install --upgrade pip
-  - pip install -r requirements/test.pip
+before_script:
+  - docker build -t elbenfreund:hamster-gtk-devel -f ./ci/dockerfile .
 
 script:
-    - tox
+    # See: https://docs.codecov.io/docs/testing-with-docker for details
+  - ci_env=`bash <(curl -s https://codecov.io/env)`
+  - docker run -v /home/travis/build/projecthamster/hamster-gtk:/hamster-gtk $ci_env elbenfreund:hamster-gtk-devel ./ci/run_docker.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,3 +18,6 @@ recursive-include docs *.rst conf.py Makefile make.bat
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 recursive-exclude * *.sw?
+
+exclude ci
+recursive-exclude ci *

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ lint:
 test:
 	py.test $(TEST_ARGS) tests/
 
-test-all: test
+test-all:
 	tox
 
 coverage:

--- a/ci/dockerfile
+++ b/ci/dockerfile
@@ -1,0 +1,31 @@
+FROM debian:stretch-slim
+
+LABEL maintainer="Eric Goller"
+
+RUN apt-get update -qq
+RUN apt-get install --no-install-recommends -y\
+ git\
+ python-setuptools\
+ python-pip\
+ python-dev\
+ python3-dev\
+ build-essential\
+ python-wheel\
+ xvfb\
+ xauth\
+ curl\
+ locales\
+ gir1.2-pango-1.0\
+ gir1.2-gtk-3.0\
+ libglib2.0-dev\
+ libgtk-3-dev\
+ python-gi\
+ python3-gi\
+ python-cairo\
+ python-gi-cairo
+
+RUN locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8
+ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN mkdir hamster-gtk
+WORKDIR hamster-gtk

--- a/ci/run_docker.sh
+++ b/ci/run_docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+err=0
+trap 'err=1' ERR
+
+# Start Xvfb
+XVFB_WHD=${XVFB_WHD:-1280x720x16}
+
+Xvfb :99 -ac -screen 0 $XVFB_WHD -nolisten tcp &
+xvfb=$!
+
+export DISPLAY=:99
+
+pip install --upgrade pip
+pip install -r requirements/test.pip
+
+python setup.py install
+make resources
+
+make test-all
+# See: https://docs.codecov.io/docs/testing-with-docker for details
+bash <(curl -s https://codecov.io/bash)
+test $err = 0

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,7 +1,7 @@
 # This file is used for local testing with and without tox as well as for
 # testing on the CI servers.
 # This file is not part of our packaging specification. It is used to generate
-# a reproduceable test environment. For check out ``docs/packaging``.
+# a reproducible test environment. For check out ``docs/packaging``.
 # For package-requirements refer to ``setup.py``.
 #
 # Some of the requirements are repeated in ``tox.ini`` to explicity check their version.

--- a/tests/misc/test_dialogs.py
+++ b/tests/misc/test_dialogs.py
@@ -13,6 +13,7 @@ import datetime
 
 from freezegun import freeze_time
 from gi.repository import Gtk
+import pytest
 
 from hamster_gtk import helpers
 from hamster_gtk.misc import dialogs
@@ -179,6 +180,7 @@ class TestEditFactDialog(object):
 
     # [FIXME]
     # Add tests for changed values.
+    @pytest.mark.xfail
     def test_updated_fact_same(self, dummy_window, fact):
         """
         Make sure the property returns Fact with matching field values.

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,22 @@
 [tox]
 # We skip isort because it conflicts with setting GTK version in inports
 # https://github.com/timothycrosley/isort/issues/295
-envlist = docs, flake8, manifest, pep257
+envlist = py27, py35, docs, flake8, manifest, pep257
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/hamster_gtk
+sitepackages=True
 whitelist_externals =
     make
-    xvfb-run
 passenv =
     SPHINXOPTS_BUILD
     SPHINXOPTS_LINKCHECK
+    XVFB_WHD
+    DISPLAY
+commands =
+    pip install -r requirements/test.pip
+    make coverage
 
 [testenv:docs]
 basepython = python2
@@ -22,7 +27,7 @@ commands =
     pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}
     make --directory=docs linkcheck BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_LINKCHECK:}
-    xvfb-run doc8
+    doc8
 
 [testenv:flake8]
 basepython = python3


### PR DESCRIPTION
This PR finally manages to establish a proper unittesting setup.

When trying to get our test setup to run with travis, several things get in our way:
1. xvfb needs to be run not with ``xvfb-run`` but as per [these instructions](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI)
2. We can not actually use any of the travis build environmens for our puposes as we target GTK>=3.10 which is unavailable in ``precise`` and ``trusty``.

As per ebassis advice, the way to deal with this is running the tests within a docker container, which is what this PR does:
1. We provide  a new docker file that if used to build a container provides us with a debian squeeze based environment that features GTK>=3.10 as well as all the packages we need for testing.
This container will also clone the ``hamster-gtk`` repository and run install the package (within the default branch, which should be ``devel``).
2. We provide a new helper script file ``run_docker.sh`` that contains the actuall test instructions to be executed within the docker container. This mainly means setting up xvfb and running the appropiate make targets. Once tests have been finished it triggers the codecov API to upload coverage reports.
3. travis config is adjusted to facilitate the new docker infrastructure and is generally slimed down as most of the actual testing is now done in the docker setup rather than within the travis config.
All travis does now is to build the docker container and run it executing the new helper script.
One thing to note here is that we trigger the codecov-API as [per instructions](https://docs.codecov.io/docs/testing-with-docker) to pass some additional environment variables to the container

While not perfect yet, this setup should finally give us a working framework to actually test the code (before we just ran linters and such) on every commit/PR greatly increasing our confidence in the codebase.

We also allow ``misc.test_dialogs.test_updated_fact_same`` to ``xfail`` as this should be fixed by the upcoming ``hamster-lib==0.13.2`` hotfix.

References/Resources:
- [Travis and ``xvfb``](https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI)
- [Travis and ``docker``](https://docs.travis-ci.com/user/docker/)
- [Codecov and docker](https://docs.codecov.io/docs/testing-with-docker)
- ebassis [travis.yml](https://github.com/ebassi/emeus/blob/master/.travis.yml)

Example dockerfile by ebassi:
```
FROM debian:stretch-slim
MAINTAINER Emmanuele Bassi <ebassi@gmail.com>

RUN apt-get update -qq && \
    apt-get install --no-install-recommends -qq -y \
        gcc \
        gettext \
        gir1.2-gtk-3.0 \
        gobject-introspection \
        locales \
        libgirepository1.0-dev \
        libgtk-3-dev \
        ninja-build \
        pkg-config \
        python3 \
        python3-pip \
        python3-setuptools \
        xvfb && \
    rm -rf /usr/share/doc/* /usr/share/man/*

RUN locale-gen C.UTF-8 && /usr/sbin/update-locale LANG=C.UTF-8

ENV LANG=C.UTF-8 LANGUAGE=C.UTF-8 LC_ALL=C.UTF-8

RUN pip3 install meson

COPY emeus-run-tests.sh /root
RUN chmod +x /root/emeus-run-tests.sh
```

And the corresponding testrunner:
```
#!/bin/bash

# Start Xvfb
XVFB_WHD=${XVFB_WHD:-1280x720x16}

Xvfb :99 -ac -screen 0 $XVFB_WHD -nolisten tcp &
xvfb=$!

export DISPLAY=:99

mkdir _build

meson --prefix /usr "$@" _build . || exit $?
ninja -C _build || exit $?
ninja -C _build test || exit $?

rm -rf _build
```

Closes: #212 , #214 