### PR TITLE
Fix encoding in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 """Packing metadata for setuptools."""
 
+from io import open
 
 try:
     from setuptools import setup, find_packages
@@ -9,10 +10,10 @@ except ImportError:
     from distutils.core import setup
 
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open('HISTORY.rst', encoding='utf-8') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [


### PR DESCRIPTION
NixOS strips environment variables, causing Python to read files as ASCII.
Since the README and HISTORY files are always in UTF-8, we will read them
using that encoding.

See also: https://github.com/garbas/pypi2nix/issues/134

-----

For Python 2 we need to use ``io.open`` to support the ``encoding`` parameter,
on Python 3 [``io.open``](https://docs.python.org/3/library/io.html?highlight=io#io.open) is just an alias for ``open``: