### PR TITLE
[#214] Specicfy 'factory-boy' version in requirements

### DIFF
--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -11,6 +11,9 @@
 check-manifest==0.35
 coverage==4.3.4
 doc8==0.7.0
+# This is needed to prevent ``pytest-factoryboy`` to pull a more recent (faulty)
+# version. See #214 for details.
+factory-boy==2.8.1
 fauxfactory==2.0.9
 flake8==3.2.1
 flake8-debugger==1.4.0


### PR DESCRIPTION
Our explicit test requirement ``pytest-factoryboy`` pulls the latest
``factory-boy`` version by default. This latest version however has bus
that break out test setup which is why this commit explicitly specifies
the last working version.

Closes: #214 