### PR TITLE
[#177] Add information about basing new PRs against 'develop' to README

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,6 +99,7 @@ Before you submit a pull request, check that it meets these guidelines:
    https://travis-ci.org/projecthamster/hamster-gtk/pull_requests
    and make sure that the tests pass for all supported Python versions.
 4. The base for the Pull Request should be against the develop branch. 
+
 Tips
 ----
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -98,7 +98,7 @@ Before you submit a pull request, check that it meets these guidelines:
 3. The pull request should work for Python 2.7 and 3.4. Check
    https://travis-ci.org/projecthamster/hamster-gtk/pull_requests
    and make sure that the tests pass for all supported Python versions.
-
+4. The base for the Pull Request should be against the develop branch. 
 Tips
 ----
 


### PR DESCRIPTION
This PR adds the information that PRs should be based against ``develop`` to the ``README``.

Closes: #177 