### PR TITLE
[#233] Cleanup testsuite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language:
   - python
 
 python:
-  - "2.7"
+  - "3.7"
 
 services:
   - docker

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -70,7 +70,7 @@ class HeaderBar(Gtk.HeaderBar):
 
     def _get_overview_button(self):
         """Return a button to open the ``Overview`` dialog."""
-        button = Gtk.Button(_("Overview"))
+        button = Gtk.Button(label=_("Overview"))
         button.connect('clicked', self._on_overview_button)
         return button
 

--- a/hamster_gtk/hamster_gtk.py
+++ b/hamster_gtk/hamster_gtk.py
@@ -34,7 +34,7 @@ import hamster_lib
 # Once we drop py2 support, we can use the builtin again but unicode support
 # under python 2 is practically non existing and manual encoding is not easily
 # possible.
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from gi.repository import Gdk, Gio, GObject, Gtk
 from hamster_lib.helpers import config_helpers
 from six import text_type
@@ -289,7 +289,7 @@ class HamsterGTK(Gtk.Application):
             config (dict): Dictionary of config key/value pairs.
 
         Returns:
-            SafeConfigParser: SafeConfigParser instance representing config.
+            ConfigParser: ConfigParser instance representing config.
         """
         def get_store():
             return config['store']
@@ -315,7 +315,7 @@ class HamsterGTK(Gtk.Application):
         def get_autocomplete_split_activity():
             return text_type(config['autocomplete_split_activity'])
 
-        cp_instance = SafeConfigParser()
+        cp_instance = ConfigParser()
         cp_instance.add_section('Backend')
         cp_instance.set('Backend', 'store', get_store())
         cp_instance.set('Backend', 'day_start', get_day_start())
@@ -401,7 +401,7 @@ class HamsterGTK(Gtk.Application):
         Write a configparser instance to a config file.
 
         Args:
-            cp_instance (SafeConfigParser): Instance to be written to file.
+            cp_instance (ConfigParser): Instance to be written to file.
         """
         config_helpers.write_config_file(configparser_instance, self._appdirs, 'hamster-gtk.conf')
 

--- a/hamster_gtk/misc/dialogs/date_range_select_dialog.py
+++ b/hamster_gtk/misc/dialogs/date_range_select_dialog.py
@@ -87,7 +87,7 @@ class DateRangeSelectDialog(Gtk.Dialog):
 
     # Widgets
     def _get_apply_button(self):
-        button = Gtk.Button(_('_Apply'), use_underline=True)
+        button = Gtk.Button(label=_('_Apply'), use_underline=True)
         return button
 
     def _get_today_widget(self):
@@ -128,11 +128,11 @@ class DateRangeSelectDialog(Gtk.Dialog):
 
     def _get_custom_range_label(self):
         """Return a 'heading' label for the widget."""
-        return Gtk.Label(_("Custom Range"))
+        return Gtk.Label(label=_("Custom Range"))
 
     def _get_custom_range_connection_label(self):
         """Return the label to be displayed between the two calendars."""
-        return Gtk.Label(_("to"))
+        return Gtk.Label(label=_("to"))
 
     # Helper
     def _get_double_label_button(self, left_label, right_label):
@@ -145,11 +145,11 @@ class DateRangeSelectDialog(Gtk.Dialog):
         grid = Gtk.Grid()
         button.add(grid)
 
-        left_label = Gtk.Label(left_label)
+        left_label = Gtk.Label(label=left_label)
         left_label.set_hexpand(True)
         left_label.set_halign(Gtk.Align.START)
 
-        right_label = Gtk.Label(right_label)
+        right_label = Gtk.Label(label=right_label)
         right_label.set_hexpand(True)
         right_label.set_halign(Gtk.Align.END)
 

--- a/hamster_gtk/misc/dialogs/edit_fact_dialog.py
+++ b/hamster_gtk/misc/dialogs/edit_fact_dialog.py
@@ -108,7 +108,7 @@ class EditFactDialog(Gtk.Dialog):
 
     def _get_old_fact_widget(self):
         """Return a widget representing the fact to be edited."""
-        label = Gtk.Label(text_type(self._fact))
+        label = Gtk.Label(label=text_type(self._fact))
         label.set_hexpand(True)
         label.set_name('EditDialogOldFactLabel')
         return label
@@ -156,12 +156,12 @@ class EditFactDialog(Gtk.Dialog):
 
     def _get_delete_button(self):
         """Return a *delete* button."""
-        return Gtk.Button(_('_Delete'), use_underline=True)
+        return Gtk.Button(label=_('_Delete'), use_underline=True)
 
     def _get_apply_button(self):
         """Return a *apply* button."""
-        return Gtk.Button(_('_Apply'), use_underline=True)
+        return Gtk.Button(label=_('_Apply'), use_underline=True)
 
     def _get_cancel_button(self):
         """Return a *cancel* button."""
-        return Gtk.Button(_('_Cancel'), use_underline=True)
+        return Gtk.Button(label=_('_Cancel'), use_underline=True)

--- a/hamster_gtk/misc/widgets/labelled_widgets_grid.py
+++ b/hamster_gtk/misc/widgets/labelled_widgets_grid.py
@@ -44,7 +44,7 @@ class LabelledWidgetsGrid(Gtk.Grid):
 
         row = 0
         for key, (label, widget) in self._fields.items():
-            label_widget = Gtk.Label(label)
+            label_widget = Gtk.Label(label=label)
             label_widget.set_use_underline(True)
             label_widget.set_mnemonic_widget(widget)
             self.attach(label_widget, 0, row, 1, 1)

--- a/hamster_gtk/overview/dialogs/overview_dialog.py
+++ b/hamster_gtk/overview/dialogs/overview_dialog.py
@@ -124,7 +124,7 @@ class OverviewDialog(Gtk.Dialog):
         self.totals_panel = widgets.Summary(self._get_highest_totals(self._totals.category, 3))
         self.main_box.pack_start(self.totals_panel, False, False, 0)
 
-        charts_button = Gtk.Button('click to show more details ...')
+        charts_button = Gtk.Button(label='click to show more details ...')
         if not self._facts:
             charts_button.set_sensitive(False)
         charts_button.connect('clicked', self._on_charts_button)

--- a/hamster_gtk/overview/widgets/charts.py
+++ b/hamster_gtk/overview/widgets/charts.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, unicode_literals
 
 import operator
 
-from gi.repository import GObject, Gtk
+from gi.repository import GObject, Gtk, GLib
 
 from hamster_gtk import helpers
 
@@ -39,11 +39,11 @@ class Charts(Gtk.Grid):
         """Initialize widget."""
         super(Charts, self).__init__()
         self.set_column_spacing(20)
-        self.attach(Gtk.Label('Categories'), 0, 0, 1, 1)
+        self.attach(Gtk.Label(label='Categories'), 0, 0, 1, 1)
         self.attach(self._get_barcharts(totals.category), 0, 1, 1, 1)
-        self.attach(Gtk.Label('Activities'), 1, 0, 1, 1)
+        self.attach(Gtk.Label(label='Activities'), 1, 0, 1, 1)
         self.attach(self._get_barcharts(totals.activity), 1, 1, 1, 1)
-        self.attach(Gtk.Label('Dates'), 2, 0, 1, 1)
+        self.attach(Gtk.Label(label='Dates'), 2, 0, 1, 1)
         self.attach(self._get_barcharts(totals.date), 2, 1, 1, 1)
 
     def _get_barcharts(self, totals):
@@ -87,7 +87,7 @@ class Charts(Gtk.Grid):
             delta_label = Gtk.Label()
             delta_label.set_selectable(True)
             delta_label.set_halign(Gtk.Align.START)
-            delta_label.set_markup("<small>{}</small>".format(GObject.markup_escape_text(
+            delta_label.set_markup("<small>{}</small>".format(GLib.markup_escape_text(
                 helpers.get_delta_string(delta))))
             grid.attach(category_label, 0, row, 1, 1)
             grid.attach(bar_chart, 1, row, 1, 1)

--- a/hamster_gtk/overview/widgets/fact_grid.py
+++ b/hamster_gtk/overview/widgets/fact_grid.py
@@ -24,7 +24,7 @@ from __future__ import absolute_import
 
 import operator
 
-from gi.repository import GObject, Gtk
+from gi.repository import GObject, Gtk, GLib
 
 from hamster_gtk import helpers
 from hamster_gtk.misc.dialogs import EditFactDialog
@@ -65,7 +65,7 @@ class FactGrid(Gtk.Grid):
         date_box.set_name('DayRowDateBox')
         date_label = Gtk.Label()
         date_label.set_name('OverviewDateLabel')
-        date_label.set_markup("<b>{}</b>".format(GObject.markup_escape_text(date_string)))
+        date_label.set_markup("<b>{}</b>".format(GLib.markup_escape_text(date_string)))
         date_label.set_valign(Gtk.Align.START)
         date_label.set_justify(Gtk.Justification.RIGHT)
         date_box.add(date_label)
@@ -165,14 +165,14 @@ class FactListRow(Gtk.ListBoxRow):
         """"Return widget to represent ``Fact.start`` and ``Fact.end``."""
         start_time = fact.start.strftime('%H:%M')
         end_time = fact.end.strftime('%H:%M')
-        time_label = Gtk.Label('{start} - {end}'.format(start=start_time, end=end_time))
+        time_label = Gtk.Label(label='{start} - {end}'.format(start=start_time, end=end_time))
         time_label.props.valign = Gtk.Align.START
         time_label.props.halign = Gtk.Align.START
         return time_label
 
     def _get_delta_widget(self, fact):
         """"Return widget to represent ``Fact.delta``."""
-        label = Gtk.Label('{} Minutes'.format(fact.get_string_delta()))
+        label = Gtk.Label(label='{} Minutes'.format(fact.get_string_delta()))
         label.props.valign = Gtk.Align.START
         label.props.halign = Gtk.Align.END
         box = Gtk.EventBox()
@@ -211,8 +211,8 @@ class FactBox(Gtk.Box):
             category = str(fact.category)
         activity_label = Gtk.Label()
         activity_label.set_markup("{activity} - {category}".format(
-            activity=GObject.markup_escape_text(fact.activity.name),
-            category=GObject.markup_escape_text(category)))
+            activity=GLib.markup_escape_text(fact.activity.name),
+            category=GLib.markup_escape_text(category)))
         activity_label.props.halign = Gtk.Align.START
         return activity_label
 
@@ -220,7 +220,7 @@ class FactBox(Gtk.Box):
         """Return widget to represent ``Fact.tags``."""
         def get_tag_widget(name):
             tag_label = Gtk.Label()
-            tag_label.set_markup("<small>{}</small>".format(GObject.markup_escape_text(name)))
+            tag_label.set_markup("<small>{}</small>".format(GLib.markup_escape_text(name)))
             tag_label.set_name('OverviewTagLabel')
             tag_box = Gtk.EventBox()
             tag_box.set_name('OverviewTagBox')
@@ -240,6 +240,6 @@ class FactBox(Gtk.Box):
         description_label.set_name('OverviewDescriptionLabel')
         description_label.set_line_wrap(True)
         description_label.set_markup("<small><i>{}</i></small>".format(
-            GObject.markup_escape_text(fact.description)))
+            GLib.markup_escape_text(fact.description)))
         description_label.props.halign = Gtk.Align.START
         return description_label

--- a/hamster_gtk/overview/widgets/misc.py
+++ b/hamster_gtk/overview/widgets/misc.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, unicode_literals
 
 from gettext import gettext as _
 
-from gi.repository import GObject, Gtk
+from gi.repository import GObject, Gtk, GLib
 from six import text_type
 
 from hamster_gtk.helpers import get_parent_window
@@ -48,7 +48,7 @@ class HeaderBar(Gtk.HeaderBar):
     # Widgets
     def _get_export_button(self):
         """Return a button to export facts."""
-        button = Gtk.Button(_("Export"))
+        button = Gtk.Button(label=_("Export"))
         button.connect('clicked', self._on_export_button_clicked)
         return button
 
@@ -56,19 +56,19 @@ class HeaderBar(Gtk.HeaderBar):
         """Return a button that opens the *select daterange* dialog."""
         # We add a dummy label which will be set properly once a daterange is
         # set.
-        button = Gtk.Button('')
+        button = Gtk.Button(label='')
         button.connect('clicked', self._on_daterange_button_clicked)
         return button
 
     def _get_prev_daterange_button(self):
         """Return a 'previous dateframe' widget."""
-        button = Gtk.Button(_("Earlier"))
+        button = Gtk.Button(label=_("Earlier"))
         button.connect('clicked', self._on_previous_daterange_button_clicked)
         return button
 
     def _get_next_daterange_button(self):
         """Return a 'next dateframe' widget."""
-        button = Gtk.Button(_("Later"))
+        button = Gtk.Button(label=_("Later"))
         button.connect('clicked', self._on_next_daterange_button_clicked)
         return button
 
@@ -128,6 +128,6 @@ class Summary(Gtk.Box):
         for category, total in category_totals:
             label = Gtk.Label()
             label.set_markup("<b>{}:</b> {} minutes".format(
-                GObject.markup_escape_text(text_type(category)),
+                GLib.markup_escape_text(text_type(category)),
                 int(total.total_seconds() / 60)))
             self.pack_start(label, False, False, 10)

--- a/hamster_gtk/preferences/preferences_dialog.py
+++ b/hamster_gtk/preferences/preferences_dialog.py
@@ -26,7 +26,7 @@ import collections
 from gettext import gettext as _
 
 import hamster_lib
-from gi.repository import GObject, Gtk
+from gi.repository import GObject, Gtk, GLib
 
 from hamster_gtk.misc.widgets import LabelledWidgetsGrid
 from hamster_gtk.preferences.widgets import (ComboFileChooser,
@@ -66,7 +66,7 @@ class PreferencesDialog(Gtk.Dialog):
             (_('Tracking'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('day_start', (_('_Day Start (HH:MM:SS)'), TimeEntry())),
                 ('fact_min_delta', (_('_Minimal Fact Duration'),
-                    HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
+                    HamsterSpinButton(SimpleAdjustment(0, GLib.MAXDOUBLE, 1)))),
             ]))),
             (_('Storage'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('store', (_('_Store'), HamsterComboBoxText(stores))),
@@ -76,7 +76,7 @@ class PreferencesDialog(Gtk.Dialog):
             ]))),
             (_('Miscellaneous'), LabelledWidgetsGrid(collections.OrderedDict([
                 ('autocomplete_activities_range', (_("Autocomplete Activities Range"),
-                    HamsterSpinButton(SimpleAdjustment(0, GObject.G_MAXDOUBLE, 1)))),
+                    HamsterSpinButton(SimpleAdjustment(0, GLib.MAXDOUBLE, 1)))),
                 ('autocomplete_split_activity',
                  (_("Autocomplete activities and categories separately"),
                   HamsterSwitch())),
@@ -87,7 +87,7 @@ class PreferencesDialog(Gtk.Dialog):
         notebook.set_name('PreferencesNotebook')
 
         for title, page in self._pages:
-            notebook.append_page(page, Gtk.Label(title))
+            notebook.append_page(page, Gtk.Label(label=title))
 
         if initial:
             self._set_config(initial)

--- a/hamster_gtk/preferences/widgets/combo_file_chooser.py
+++ b/hamster_gtk/preferences/widgets/combo_file_chooser.py
@@ -47,7 +47,7 @@ class ComboFileChooser(Gtk.Grid, ConfigWidget):
         self._entry = Gtk.Entry()
         self._entry.set_hexpand(True)
 
-        self._button = Gtk.Button(_("Choose"))
+        self._button = Gtk.Button(label=_("Choose"))
         self._button.connect('clicked', self._on_choose_clicked)
 
         self.attach(self._entry, 0, 0, 1, 1)

--- a/hamster_gtk/preferences/widgets/hamster_spin_button.py
+++ b/hamster_gtk/preferences/widgets/hamster_spin_button.py
@@ -62,8 +62,13 @@ class HamsterSpinButton(Gtk.SpinButton, ConfigWidget):
         if adjustment is not None:
             if isinstance(adjustment, SimpleAdjustment):
                 self._validate_simple_adjustment(adjustment)
-                adjustment = Gtk.Adjustment(adjustment.min, adjustment.min, adjustment.max,
-                    adjustment.step, 10 * adjustment.step, 0)
+                adjustment = Gtk.Adjustment(
+                    value=adjustment.min,
+                    lower=adjustment.min,
+                    upper=adjustment.max,
+                    step_increment=adjustment.step, page_increment=(10 * adjustment.step),
+                    page_size=0
+                )
             elif not isinstance(adjustment, Gtk.Adjustment):
                 raise ValueError('Instance of SimpleAdjustment or Gtk.Adjustment is expected.')
 

--- a/hamster_gtk/tracking/screens.py
+++ b/hamster_gtk/tracking/screens.py
@@ -107,21 +107,21 @@ class CurrentFactBox(Gtk.Box):
 
     def _get_fact_label(self, fact):
         text = '{fact}'.format(fact=fact)
-        return Gtk.Label(text)
+        return Gtk.Label(label=text)
 
     def _get_cancel_button(self):
-        cancel_button = Gtk.Button(_('Cancel'))
+        cancel_button = Gtk.Button(label=_('Cancel'))
         cancel_button.connect('clicked', self._on_cancel_button)
         return cancel_button
 
     def _get_save_button(self):
-        save_button = Gtk.Button(_('Stop & Save'))
+        save_button = Gtk.Button(label=_('Stop & Save'))
         save_button.connect('clicked', self._on_save_button)
         return save_button
 
     def _get_invalid_label(self):
         """Return placeholder in case there is no current ongoing fact present."""
-        return Gtk.Label(_("There currently is no ongoing fact that could be displayed."))
+        return Gtk.Label(label=_("There currently is no ongoing fact that could be displayed."))
 
     # Callbacks
     def _on_cancel_button(self, button):
@@ -174,7 +174,7 @@ class StartTrackingBox(Gtk.Box):
         # Refactor to call separate 'get_widget' methods instead.
         # Introduction text
         text = _('Currently no tracked activity. Want to start one?')
-        self.current_fact_label = Gtk.Label(text)
+        self.current_fact_label = Gtk.Label(label=text)
         self.pack_start(self.current_fact_label, False, False, 0)
 
         # Fact entry field

--- a/requirements/docs.pip
+++ b/requirements/docs.pip
@@ -1,4 +1,4 @@
 # This file specifies all packages required to build the documentation.
 
-Sphinx==1.5.2
-sphinx-rtd-theme==0.1.9
+Sphinx
+sphinx-rtd-theme

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -8,24 +8,22 @@
 # Including them here as well has the advantage of keeping them up to date via requires.io
 
 
-check-manifest==0.35
-coverage==4.3.4
-doc8==0.7.0
-# This is needed to prevent ``pytest-factoryboy`` to pull a more recent (faulty)
-# version. See #214 for details.
-factory-boy==2.8.1
-fauxfactory==2.0.9
-flake8==3.2.1
-flake8-debugger==1.4.0
-flake8-print==2.0.2
-freezegun==0.3.8
-future==0.16.0
-isort==4.2.5
-pep8-naming==0.4.1
-pep257==0.7.0
-pytest==3.0.6
-pytest-faker==2.0.0
-pytest-factoryboy==1.3.0
-pytest-mock==1.5.0
-pytest-xvfb==1.0.0
-tox==2.5.0
+check-manifest
+coverage
+doc8
+factory-boy
+fauxfactory
+flake8
+flake8-debugger
+flake8-print
+freezegun
+future
+isort
+pep8-naming
+pep257
+pytest
+pytest-faker
+pytest-factoryboy
+pytest-mock
+pytest-xvfb
+tox

--- a/tests/preferences/widgets/conftest.py
+++ b/tests/preferences/widgets/conftest.py
@@ -61,13 +61,14 @@ def paths(request, faker):
 @pytest.fixture
 def adjustment(request, numbers):
     """Return a list of random numbers."""
-    value = sorted(numbers)[len(numbers) // 2]
-    lower = min(numbers)
-    upper = max(numbers)
-    step_increment = 1
-    page_increment = 5
-    page_size = 0
-    return Gtk.Adjustment(value, lower, upper, step_increment, page_increment, page_size)
+    return Gtk.Adjustment(
+        value=sorted(numbers)[len(numbers) // 2],
+        lower=min(numbers),
+        upper=max(numbers),
+        step_increment=1,
+        page_increment=5,
+        page_size=0
+    )
 
 
 @pytest.fixture

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -11,14 +11,14 @@ import hamster_gtk.helpers as helpers
 
 def test_get_parent_window_standalone(request):
     """Make sure the parent window of a windowless widget is None."""
-    label = Gtk.Label('foo')
+    label = Gtk.Label(label='foo')
     assert helpers.get_parent_window(label) is None
 
 
 def test_get_parent_window(request):
     """Make sure the parent window of a widget placed in the window is determined correctly."""
     window = Gtk.Window()
-    label = Gtk.Label('foo')
+    label = Gtk.Label(label='foo')
     window.add(label)
     assert helpers.get_parent_window(label) == window
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 # We skip isort because it conflicts with setting GTK version in inports
 # https://github.com/timothycrosley/isort/issues/295
-envlist = py27, py35, docs, flake8, manifest, pep257
+envlist = py37, docs, flake8, manifest, pep257
 
 [testenv]
 setenv =
@@ -19,10 +19,10 @@ commands =
     make coverage
 
 [testenv:docs]
-basepython = python2
+basepython = python3
 # We need access to GTK for autodocs
 sitepackages = True
-deps = doc8==0.7.0
+deps = doc8
 commands =
     pip install -r requirements/docs.pip
     make docs BUILDDIR={envtmpdir} SPHINXOPTS={env:SPHINXOPTS_BUILD:''}
@@ -32,16 +32,16 @@ commands =
 [testenv:flake8]
 basepython = python3
 deps =
-    flake8==3.2.1
-    flake8-debugger==1.4.0
-    flake8-print==2.0.2
-    pep8-naming==0.4.1
+    flake8
+    flake8-debugger
+    flake8-print
+    pep8-naming
 skip_install = True
 commands = flake8 setup.py hamster_gtk/ tests/
 
 [testenv:manifest]
 basepython = python3
-deps = check-manifest==0.35
+deps = check-manifest
 skip_install = True
 commands =
     check-manifest -v
@@ -49,7 +49,5 @@ commands =
 [testenv:pep257]
 basepython = python3
 skip_install = True
-deps =
-    pep257==0.7.0
-commands =
-    pep257 setup.py hamster_gtk/ tests/
+deps = pep257
+commands = pep257 setup.py hamster_gtk/ tests/


### PR DESCRIPTION
In order to make the testsuite play nice with the current external libraries, the following changes were made:

- Change ``SafeConfigParser`` to ``ConfigParser``
- Drop python2 support from the test suite (`tox` , ``travis``)
- Use explicit ``kwargs`` instead of ``args`` when instantiating `Gtk.Label/Button` etc instances.
- Remove version pinning for ``docs.pip`` and `tests.pip`.

Closes: #233 
